### PR TITLE
World selector parsing moved to QThread

### DIFF
--- a/src/main/python/amulet_editor/data/minecraft/__init__.py
+++ b/src/main/python/amulet_editor/data/minecraft/__init__.py
@@ -1,2 +1,2 @@
 from amulet_editor.data.minecraft._directory import save_directories
-from amulet_editor.data.minecraft._saves import locate_worlds
+from amulet_editor.data.minecraft._saves import locate_levels

--- a/src/main/python/amulet_editor/data/minecraft/_saves.py
+++ b/src/main/python/amulet_editor/data/minecraft/_saves.py
@@ -17,7 +17,7 @@ def locate_file(file: str, directory: str, recursive=False) -> list[str]:
     return paths
 
 
-def locate_worlds(directories: list[str]) -> list[str]:
+def locate_levels(directories: list[str]) -> list[str]:
     """
     Returns a list of paths to all identified minecraft level.dat
     files in the list of provided directories.

--- a/src/main/python/amulet_editor/models/widgets/_card.py
+++ b/src/main/python/amulet_editor/models/widgets/_card.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from amulet_editor.data import build
 from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Color, Theme
+from amulet_editor.data import build
 from amulet_editor.models.widgets._icon import QSvgIcon
 from amulet_editor.models.widgets._label import QElidedLabel
 from PySide6.QtCore import QEvent, QSize, Qt
@@ -44,7 +44,6 @@ class QPixCard(QPushButton):
 
     def addLabel(self, text: str):
         label = QElidedLabel(text, self)
-        label.setAttribute(Qt.WA_TransparentForMouseEvents)
         self.layout().itemAt(1).widget().layout().addWidget(label)
 
     def layout(self) -> QHBoxLayout:

--- a/src/main/python/amulet_editor/tools/startup/_main.py
+++ b/src/main/python/amulet_editor/tools/startup/_main.py
@@ -1,19 +1,14 @@
 from functools import partial
-from typing import Callable, Optional
 
 from amulet_editor.data import packages, project
 from amulet_editor.models.package import AmuletTool, AmuletView
 from amulet_editor.models.widgets import QMenuWidget
-from amulet_editor.tools.programs import Programs
 from amulet_editor.tools.project import Project
 from amulet_editor.tools.startup._models import Menu, Navigate
-from amulet_editor.tools.startup.pages._import_level import ImportLevelMenu
 from amulet_editor.tools.startup.pages._new_project import NewProjectMenu
 from amulet_editor.tools.startup.pages._open_world import OpenWorldMenu
-from amulet_editor.tools.startup.pages._select_packages import SelectPackagesPage
 from amulet_editor.tools.startup.pages._startup import StartupPage
 from amulet_editor.tools.startup.panels._startup import StartupPanel
-from amulet_editor.tools.startup.panels._world_selection import WorldSelectionPanel
 from PySide6.QtCore import QCoreApplication, QObject
 from PySide6.QtWidgets import QWidget
 
@@ -76,6 +71,10 @@ class StartupManager(QObject):
             partial(self.set_menu_page, NewProjectMenu)
         )
 
+        self.menu_page.clicked_cancel.connect(partial(self.set_startup_page))
+        self.menu_page.clicked_back.connect(partial(self.menu_back))
+        self.menu_page.clicked_next.connect(partial(self.menu_next))
+
         self.set_startup_page()
 
     def set_startup_page(self) -> None:
@@ -93,11 +92,6 @@ class StartupManager(QObject):
 
         self.menu_list.append(menu)
         self.set_menu(menu)
-
-        # Connect signals
-        self.menu_page.clicked_cancel.connect(partial(self.set_startup_page))
-        self.menu_page.clicked_back.connect(partial(self.menu_back))
-        self.menu_page.clicked_next.connect(partial(self.menu_next))
 
         # Set plugin view
         self.plugin.set_page(self.menu_page)

--- a/src/main/python/amulet_editor/tools/startup/_widgets.py
+++ b/src/main/python/amulet_editor/tools/startup/_widgets.py
@@ -1,12 +1,12 @@
 import pathlib
 from typing import Optional
 
-from amulet_editor.data import build
 from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Color, Theme
+from amulet_editor.data import build
+from amulet_editor.models.minecraft import LevelData
 from amulet_editor.models.widgets._icon import QSvgIcon
 from amulet_editor.models.widgets._label import QElidedLabel
-from amulet_editor.models.minecraft import LevelData
 from PySide6.QtCore import QCoreApplication, QEvent, QSize, Qt
 from PySide6.QtGui import QEnterEvent, QImage, QPixmap
 from PySide6.QtWidgets import (
@@ -141,64 +141,69 @@ class QLevelSelectionCard(QPushButton):
     def setLayout(self, arg__1: QLayout) -> None:
         return None
 
-    def setLevel(self, level_data: LevelData):
-        icon_path = (
-            level_data.icon_path
-            if level_data.icon_path is not None
-            else build.get_resource("images/missing_world_icon.png")
-        )
-        level_icon = QPixmap(QImage(icon_path))
-        level_icon = level_icon.scaledToHeight(80)
+    def setLevel(self, level_data: Optional[LevelData]):
+        if level_data is not None:
+            icon_path = (
+                level_data.icon_path
+                if level_data.icon_path is not None
+                else build.get_resource("images/missing_world_icon.png")
+            )
+            level_icon = QPixmap(QImage(icon_path))
+            level_icon = level_icon.scaledToHeight(80)
 
-        level_name = level_data.name.get_html(font_weight=600)
-        file_name = pathlib.PurePath(level_data.path).name
-        version = f"{level_data.edition} - {level_data.version}"
-        last_played = (
-            level_data.last_played.astimezone(tz=None)
-            .strftime("%B %d, %Y %I:%M %p")
-            .replace(" 0", " ")
-        )
+            level_name = level_data.name.get_html(font_weight=600)
+            file_name = pathlib.PurePath(level_data.path).name
+            version = f"{level_data.edition} - {level_data.version}"
+            last_played = (
+                level_data.last_played.astimezone(tz=None)
+                .strftime("%B %d, %Y %I:%M %p")
+                .replace(" 0", " ")
+            )
 
-        widget = QWidget(self.swgt_container)
-        grid = QGridLayout(widget)
+            widget = QWidget(self.swgt_container)
+            grid = QGridLayout(widget)
 
-        lbl_pixmap = QLabel(widget)
-        lbl_pixmap.setPixmap(level_icon)
-        lbl_pixmap.setProperty("backgroundColor", "background")
-        lbl_pixmap.setProperty("border", "surface")
-        lbl_pixmap.setProperty("borderRadiusVisible", True)
-        lbl_pixmap.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+            lbl_pixmap = QLabel(widget)
+            lbl_pixmap.setPixmap(level_icon)
+            lbl_pixmap.setProperty("backgroundColor", "background")
+            lbl_pixmap.setProperty("border", "surface")
+            lbl_pixmap.setProperty("borderRadiusVisible", True)
+            lbl_pixmap.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
 
-        lbl_level_name = QElidedLabel(level_name, widget)
-        lbl_level_name.setAttribute(Qt.WA_TransparentForMouseEvents)
+            lbl_level_name = QElidedLabel(level_name, widget)
+            lbl_level_name.setAttribute(Qt.WA_TransparentForMouseEvents)
 
-        lbl_file_name = QElidedLabel(file_name, widget)
+            lbl_file_name = QElidedLabel(file_name, widget)
 
-        lbl_version = QElidedLabel(version, widget)
+            lbl_version = QElidedLabel(version, widget)
 
-        lbl_last_played = QElidedLabel(last_played, widget)
+            lbl_last_played = QElidedLabel(last_played, widget)
 
-        grid.addWidget(lbl_pixmap, 0, 0, 4, 1)
-        grid.addWidget(lbl_level_name, 0, 1, 1, 1)
-        grid.addWidget(lbl_file_name, 1, 1, 1, 1)
-        grid.addWidget(lbl_version, 2, 1, 1, 1)
-        grid.addWidget(lbl_last_played, 3, 1, 1, 1)
+            grid.addWidget(lbl_pixmap, 0, 0, 4, 1)
+            grid.addWidget(lbl_level_name, 0, 1, 1, 1)
+            grid.addWidget(lbl_file_name, 1, 1, 1, 1)
+            grid.addWidget(lbl_version, 2, 1, 1, 1)
+            grid.addWidget(lbl_last_played, 3, 1, 1, 1)
 
-        widget.setLayout(grid)
+            widget.setLayout(grid)
 
-        if self.swgt_container.widget(1) is not None:
-            self.swgt_container.removeWidget(self.swgt_container.widget(1))
+            if self.swgt_container.widget(1) is not None:
+                self.swgt_container.removeWidget(self.swgt_container.widget(1))
 
-        self.swgt_container.addWidget(widget)
-        self.swgt_container.setCurrentIndex(1)
+            self.swgt_container.addWidget(widget)
+            self.swgt_container.setCurrentIndex(1)
+        else:
+            self.swgt_container.setCurrentIndex(0)
 
     def layout(self) -> QHBoxLayout:
         return super().layout()
 
     def setupUi(self) -> None:
         self.swgt_container = QStackedWidget(self)
+        self.swgt_container.setAttribute(Qt.WA_TransparentForMouseEvents)
 
         self.wgt_info = QWidget(self.swgt_container)
+        self.wgt_info.setAttribute(Qt.WA_TransparentForMouseEvents)
 
         self.lbl_info = QLabel(self.wgt_info)
         self.lbl_info.setProperty("color", "on_surface")

--- a/src/main/python/amulet_editor/tools/startup/pages/_import_level.py
+++ b/src/main/python/amulet_editor/tools/startup/pages/_import_level.py
@@ -1,28 +1,22 @@
 import os
-import pathlib
 from functools import partial
 from typing import Callable, Optional
 
 import amulet
-from amulet_editor.data import build, minecraft, paths
+from amulet_editor.data import minecraft, paths
 from amulet_editor.models.generic import Observer
 from amulet_editor.models.minecraft import LevelData
-from amulet_editor.models.widgets import QElidedLabel
 from amulet_editor.tools.startup._models import Menu, ProjectData
 from amulet_editor.tools.startup._widgets import QIconButton, QLevelSelectionCard
 from amulet_editor.tools.startup.panels._world_selection import WorldSelectionPanel
 from PySide6.QtCore import QCoreApplication, QObject, QSize
-from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
     QFrame,
-    QGridLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QPushButton,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )


### PR DESCRIPTION
When the World Selection panel is instantiated, the process of loading level previews now occurs in a QThread to prevent the application from freezing.