### PR TITLE
Removed wait in installer when finshed

### DIFF
--- a/build_system/installer/windows/Installer.nsi
+++ b/build_system/installer/windows/Installer.nsi
@@ -57,7 +57,6 @@ FunctionEnd
   !insertmacro MUI_PAGE_WELCOME
   !insertmacro MUI_PAGE_DIRECTORY
   !insertmacro MUI_PAGE_INSTFILES
-    !define MUI_FINISHPAGE_NOAUTOCLOSE
     !define MUI_FINISHPAGE_RUN
     !define MUI_FINISHPAGE_RUN_CHECKED
     !define MUI_FINISHPAGE_RUN_TEXT "Run ${display_name}"


### PR DESCRIPTION
When the installer had finished installing the files it would wait on the log file page.
It is not obvious that it had finished installing and that the user had the press the next button.
Removing this line makes the installer jump to the finished page automatically when it has finished installing making it very obvious that it has finished.