### PR TITLE
Refactored SVG widget and button and improved drag container

### DIFF
--- a/src/amulet_editor/application/windows/_amulet_window.py
+++ b/src/amulet_editor/application/windows/_amulet_window.py
@@ -5,7 +5,7 @@ from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Theme
 from amulet_editor.data import packages, project
 from amulet_editor.models.package import AmuletTool
-from amulet_editor.models.widgets import QDragContainer, QDragIconButton, QIconButton
+from amulet_editor.models.widgets import ADragContainer, ATooltipIconButton
 from amulet_editor.tools.packages import Packages
 from amulet_editor.tools.settings import Settings
 from amulet_editor.tools.startup import Startup
@@ -194,29 +194,22 @@ class AmuletWindow(QMainWindow):
 
     def load_tool(self, tool: AmuletTool, static: bool = False) -> None:
         """
-        Loads tool into the main application toolbar.\n
+        Loads tool into the main application toolbar.
         Tools marked as static are considered core to the functionality of the editor and thus cannot be removed once loaded.
         """
-        if static:
-            icon_button = QIconButton(self.frm_static_tools)
-        else:
-            icon_button = QDragIconButton(self.wgt_dynamic_tools)
-            icon_button.setData(tool.name)
-
+        icon_button = ATooltipIconButton(tool.icon_name, self)
         icon_button.clicked.connect(partial(self.show_tool, tool))
-        icon_button.setAutoRaise(True)
         icon_button.setCheckable(True)
         icon_button.setFixedSize(QSize(40, 40))
-        icon_button.toolTip().setText(tool.name)
+        icon_button.setToolTip(tool.name)
         icon_button.setIconSize(QSize(30, 30))
-        icon_button.setIcon(tool.icon_name)
 
         self.btng_menus.addButton(icon_button)
 
         if static:
             self.lyt_static_tools.addWidget(icon_button)
         else:
-            self.wgt_dynamic_tools.addItem(icon_button)
+            self.wgt_dynamic_tools.add_item(icon_button)
 
         tool.page.changed.connect(partial(self.change_page, tool))
         tool.primary_panel.changed.connect(partial(self.change_primary_panel, tool))
@@ -310,7 +303,7 @@ class AmuletWindow(QMainWindow):
         self.frm_static_tools.setFixedWidth(40)
 
         # Configure widget for 'Dynamic Menu' items
-        self.wgt_dynamic_tools = QDragContainer(self.frm_static_tools)
+        self.wgt_dynamic_tools = ADragContainer(parent=self.frm_static_tools)
         self.wgt_dynamic_tools.layout().setAlignment(Qt.AlignTop)
         self.wgt_dynamic_tools.layout().setContentsMargins(0, 0, 0, 0)
         self.wgt_dynamic_tools.layout().setSpacing(0)

--- a/src/amulet_editor/models/widgets/__init__.py
+++ b/src/amulet_editor/models/widgets/__init__.py
@@ -1,5 +1,5 @@
 from amulet_editor.models.widgets._card import QLinkCard, QPixCard
 from amulet_editor.models.widgets._draggable import QDragContainer, QDragIconButton
-from amulet_editor.models.widgets._icon import QIconButton, QSvgIcon
+from amulet_editor.models.widgets._icon import QIconButton, QSvgIcon, AStylableSvgWidget, AIconButton, ATooltipIconButton
 from amulet_editor.models.widgets._label import QElidedLabel
 from amulet_editor.models.widgets._menu import QMenuWidget

--- a/src/amulet_editor/models/widgets/__init__.py
+++ b/src/amulet_editor/models/widgets/__init__.py
@@ -1,4 +1,4 @@
-from amulet_editor.models.widgets._card import QLinkCard, QPixCard
+from amulet_editor.models.widgets._card import QLinkCard, ALinkCard, QPixCard
 from amulet_editor.models.widgets._draggable import QDragContainer, QDragIconButton
 from amulet_editor.models.widgets._icon import QIconButton, QSvgIcon, AStylableSvgWidget, AIconButton, ATooltipIconButton
 from amulet_editor.models.widgets._label import QElidedLabel

--- a/src/amulet_editor/models/widgets/__init__.py
+++ b/src/amulet_editor/models/widgets/__init__.py
@@ -1,5 +1,5 @@
 from amulet_editor.models.widgets._card import QLinkCard, ALinkCard, QPixCard
-from amulet_editor.models.widgets._draggable import QDragContainer, QDragIconButton
+from amulet_editor.models.widgets._draggable import QDragContainer, QDragIconButton, ADragContainer
 from amulet_editor.models.widgets._icon import QIconButton, QSvgIcon, AStylableSvgWidget, AIconButton, ATooltipIconButton
 from amulet_editor.models.widgets._label import QElidedLabel
 from amulet_editor.models.widgets._menu import QMenuWidget

--- a/src/amulet_editor/models/widgets/_card.py
+++ b/src/amulet_editor/models/widgets/_card.py
@@ -3,8 +3,6 @@ from typing import Optional
 from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Color, Theme
 from amulet_editor.data import build
-from amulet_editor.models.widgets._icon import QSvgIcon
-from amulet_editor.models.widgets._label import QElidedLabel
 from PySide6.QtCore import QEvent, QSize, Qt
 from PySide6.QtGui import QEnterEvent, QPixmap
 from PySide6.QtWidgets import (
@@ -17,6 +15,9 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from ._icon import QSvgIcon, AStylableSvgWidget
+from ._label import QElidedLabel
 
 
 class QPixCard(QPushButton):

--- a/src/amulet_editor/models/widgets/_card.py
+++ b/src/amulet_editor/models/widgets/_card.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import warnings
 
 from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Color, Theme
@@ -58,6 +59,7 @@ class QLinkCard(QPushButton):
         icon: Optional[str] = None,
         parent: Optional[QWidget] = None,
     ) -> None:
+        warnings.warn("QLinkCard is depreciated use ALinkCard instead", DeprecationWarning)
         super().__init__(parent=parent)
 
         self.icon_size = QSize(15, 15)
@@ -132,3 +134,56 @@ class QLinkCard(QPushButton):
         self.repaint(appearance.theme().on_surface)
         self.lbl_ext_icon.setHidden(True)
         return super().leaveEvent(event)
+
+
+class ALinkCard(QPushButton):
+    svg_link_icon: Optional[AStylableSvgWidget]
+
+    def __init__(
+        self,
+        text: str,
+        icon: Optional[str] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setProperty("hover", "false")  # X:hover > Y style is broken.
+
+        layout = QHBoxLayout()
+
+        if icon:
+            self.svg_link_icon = AStylableSvgWidget(icon)
+            self.svg_link_icon.setAttribute(Qt.WA_TransparentForMouseEvents)
+            self.svg_link_icon.setFixedSize(15, 15)
+            layout.addWidget(self.svg_link_icon)
+        else:
+            self.svg_link_icon = None
+
+        self.lbl_description = QElidedLabel(text)
+        self.lbl_description.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.lbl_description.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        layout.addWidget(self.lbl_description)
+
+        self.svg_ext_icon = AStylableSvgWidget(build.get_resource(f"icons/tabler/external-link.svg"))
+        self.svg_ext_icon.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.svg_ext_icon.setFixedSize(15, 15)
+        self.svg_ext_icon.setHidden(True)
+        layout.addWidget(self.svg_ext_icon)
+
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(5)
+
+        self.setLayout(layout)
+        self.setMinimumSize(self.minimumSizeHint())
+
+    def enterEvent(self, event: QEnterEvent):
+        self.svg_ext_icon.setHidden(False)
+        self.setProperty("hover", "true")
+        self.setStyleSheet("/* /")  # Force a style update.
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent):
+        self.svg_ext_icon.setHidden(True)
+        self.setProperty("hover", "false")
+        self.setStyleSheet("/* /")  # Force a style update.
+        super().leaveEvent(event)

--- a/src/amulet_editor/models/widgets/_icon.py
+++ b/src/amulet_editor/models/widgets/_icon.py
@@ -1,15 +1,19 @@
 from typing import Optional
+import warnings
 
+from amulet_editor.data import build
 from amulet_editor.data.build import get_resource
 from amulet_editor.models.widgets._label import QHoverLabel
 from PySide6 import QtGui
-from PySide6.QtCore import QEvent, QSize
-from PySide6.QtGui import QColor, QEnterEvent, QIcon, QMouseEvent, QPainter
-from PySide6.QtWidgets import QToolButton, QWidget
+from PySide6.QtCore import QEvent, QSize, Qt
+from PySide6.QtGui import QColor, QEnterEvent, QIcon, QPainter, QPaintEvent, QImage
+from PySide6.QtWidgets import QToolButton, QWidget, QStyleOption, QStyle, QVBoxLayout, QPushButton
+from PySide6.QtSvgWidgets import QSvgWidget
 
 
 class QSvgIcon(QIcon):
     def __init__(self, filename: str, size: QSize, color: QColor) -> None:
+        warnings.warn("QSvgIcon is depreciated. Use AStylableSvgWidget instead", DeprecationWarning)
         pixmap = QIcon(filename).pixmap(size)
 
         painter = QPainter(pixmap)
@@ -24,6 +28,7 @@ class QSvgIcon(QIcon):
 
 class QIconButton(QToolButton):
     def __init__(self, parent: QWidget) -> None:
+        warnings.warn("QIconButton is depreciated. Use AIconButton instead", DeprecationWarning)
         super().__init__(parent)
 
         self._icon_name = "question-mark"
@@ -71,3 +76,95 @@ class QIconButton(QToolButton):
 
     def leaveEvent(self, event: QEvent):
         self._hlbl_tooltip.hide()
+
+
+class AStylableSvgWidget(QSvgWidget):
+    """
+    A subclass of QSvgWidget that adds support for colouring via style sheets.
+    Set the background via QSS and this widget will merge the colour of the background with the transparency of the SVG icon.
+    """
+    def paintEvent(self, event: QPaintEvent):
+        buffer_width = max(self.width(), 50)
+        buffer_height = max(self.height(), 50)
+
+        buffer = QImage(buffer_width, buffer_height, QImage.Format_ARGB32)
+        buffer.fill(QColor(0, 0, 0, 0))  # Fill with transparency
+
+        # Init the painter
+        painter = QPainter(buffer)
+
+        # Draw the SVG
+        self.renderer().render(painter)
+        # If the buffer is larger than the widget apply scaling
+        painter.scale(buffer_width/self.width(), buffer_height/self.height())
+
+        # Use the alpha current alpha with the future colour
+        painter.setCompositionMode(QPainter.CompositionMode_SourceIn)
+        # Draw the normal background
+        opt = QStyleOption()
+        opt.initFrom(self)
+        self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
+
+        # Finish painting
+        painter.end()
+
+        # Draw the image to the widget.
+        painter = QPainter(self)
+        painter.drawImage(self.rect(), buffer)
+        painter.end()
+
+
+class AIconButton(QPushButton):
+    """A QPushButton containing a stylable icon."""
+    def __init__(self, icon_name: str = "question-mark.svg", parent: QWidget = None):
+        super().__init__(parent)
+        self.setProperty("hover", "false")
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setAlignment(Qt.AlignCenter)
+        self._icon = AStylableSvgWidget(build.get_resource(f"icons/tabler/{icon_name}"))
+        self._layout.addWidget(self._icon)
+
+    def setIcon(self, icon_name: Optional[str] = None):
+        self._icon.load(build.get_resource(f"icons/tabler/{icon_name}"))
+
+    def setIconSize(self, size: QSize):
+        self._icon.setFixedSize(size)
+
+    def enterEvent(self, event: QEnterEvent):
+        self.setProperty("hover", "true")
+        self.setStyleSheet("/* /")  # Force a style update.
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent):
+        if not self.isChecked():
+            self.setProperty("hover", "false")
+        self.setStyleSheet("/* /")  # Force a style update.
+        super().leaveEvent(event)
+
+
+class ATooltipIconButton(AIconButton):
+    # TODO: look into making this work without a subclass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._hlbl_tooltip: Optional[QHoverLabel] = None
+
+    def enterEvent(self, event: QEnterEvent):
+        if self._hlbl_tooltip is not None and len(self._hlbl_tooltip.text()) > 0:
+            self._hlbl_tooltip.show()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent):
+        if self._hlbl_tooltip is not None:
+            self._hlbl_tooltip.hide()
+        super().leaveEvent(event)
+
+    def toolTip(self) -> str:
+        return "" if self._hlbl_tooltip is None else self._hlbl_tooltip.text()
+
+    def setToolTip(self, label: str) -> None:
+        if self._hlbl_tooltip is None:
+            self._hlbl_tooltip = QHoverLabel(label, self)
+            self._hlbl_tooltip.hide()
+        else:
+            self._hlbl_tooltip.setText(label)

--- a/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
+++ b/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
@@ -511,11 +511,15 @@ QToolButton:pressed {{
     background-color: "{surface}";
     color: "{on_surface}";
 }}
-QIconButton:checked {{
+QIconButton:checked,
+AIconButton:checked,
+{{
     background-color: "{secondary.darker.50}";
     color: "{on_secondary}";
 }}
-QIconButton:pressed {{
+QIconButton:pressed,
+AIconButton:pressed,
+{{
     background-color: "{primary}";
     color: "{on_primary}";
 }}

--- a/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
+++ b/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
@@ -539,12 +539,12 @@ QToolTip {{
     color: "{on_background}";
 }}
 
-/* QLinkCard[auto_hide=true]:!hover:!pressed:!checked {{
-    background: transparent;
-    border: none;
-    color: "{on_surface}";
+AIconButton[hover="false"] > AStylableSvgWidget
+{{
+    background-color: "{on_surface}";
 }}
-QLinkCard[auto_hide=true]:!hover:!pressed {{
-    border: none;
-    color: "{on_surface}";
-}} */
+
+AIconButton[hover="true"] > AStylableSvgWidget
+{{
+    background-color: "{on_primary}";
+}}

--- a/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
+++ b/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
@@ -539,12 +539,24 @@ QToolTip {{
     color: "{on_background}";
 }}
 
+ALinkCard[hover="false"] > AStylableSvgWidget,
 AIconButton[hover="false"] > AStylableSvgWidget
 {{
     background-color: "{on_surface}";
 }}
 
+ALinkCard[hover="true"] > AStylableSvgWidget,
 AIconButton[hover="true"] > AStylableSvgWidget
 {{
     background-color: "{on_primary}";
+}}
+
+ALinkCard[hover="false"] > QElidedLabel
+{{
+    color: "{on_surface}";
+}}
+
+ALinkCard[hover="true"] > QElidedLabel
+{{
+    color: "{on_primary}";
 }}

--- a/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
+++ b/src/amulet_editor/resources/themes/_default/style_sheets/application.qss
@@ -512,13 +512,13 @@ QToolButton:pressed {{
     color: "{on_surface}";
 }}
 QIconButton:checked,
-AIconButton:checked,
+AIconButton:checked
 {{
     background-color: "{secondary.darker.50}";
     color: "{on_secondary}";
 }}
 QIconButton:pressed,
-AIconButton:pressed,
+AIconButton:pressed
 {{
     background-color: "{primary}";
     color: "{on_primary}";

--- a/src/amulet_editor/tools/programs/panels/_programs.py
+++ b/src/amulet_editor/tools/programs/panels/_programs.py
@@ -3,7 +3,6 @@ from functools import partial
 from typing import Optional
 
 import amulet
-from amulet_editor.models.widgets import QLinkCard
 from amulet_editor.data import build, project
 from amulet_editor.models.minecraft import LevelData
 from PySide6.QtCore import QDir, QSize, Qt, Signal

--- a/src/amulet_editor/tools/project/panels/_project.py
+++ b/src/amulet_editor/tools/project/panels/_project.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Optional
 
 import amulet
-from amulet_editor.models.widgets import QLinkCard
+from amulet_editor.models.widgets import ALinkCard
 from amulet_editor.data import build, project
 from amulet_editor.models.minecraft import LevelData
 from PySide6.QtCore import QDir, QSize, Qt, Signal
@@ -28,7 +28,7 @@ class ProjectPanel(QWidget):
 
         self.setupUi()
 
-        self.crd_directory = QLinkCard(
+        self.crd_directory = ALinkCard(
             "", build.get_resource(f"icons/tabler/folder.svg"), self
         )
         self.frm_directory.layout().addWidget(self.crd_directory)

--- a/src/amulet_editor/tools/startup/_widgets.py
+++ b/src/amulet_editor/tools/startup/_widgets.py
@@ -1,5 +1,6 @@
 import pathlib
 from typing import Optional
+import warnings
 
 from amulet_editor.application import appearance
 from amulet_editor.application.appearance import Color, Theme
@@ -24,6 +25,7 @@ from PySide6.QtWidgets import (
 
 class QIconButton(QToolButton):
     def __init__(self, parent: QWidget) -> None:
+        warnings.warn("QIconButton is depreciated. Use AIconButton instead", DeprecationWarning)
         super().__init__(parent)
 
         self._icon_name = "question-mark"

--- a/src/amulet_editor/tools/startup/pages/_import_level.py
+++ b/src/amulet_editor/tools/startup/pages/_import_level.py
@@ -6,8 +6,9 @@ import amulet
 from amulet_editor.data import minecraft, paths
 from amulet_editor.models.generic import Observer
 from amulet_editor.models.minecraft import LevelData
+from amulet_editor.models.widgets import AIconButton
 from amulet_editor.tools.startup._models import Menu, ProjectData
-from amulet_editor.tools.startup._widgets import QIconButton, QLevelSelectionCard
+from amulet_editor.tools.startup._widgets import QLevelSelectionCard
 from amulet_editor.tools.startup.panels._world_selection import WorldSelectionPanel
 from PySide6.QtCore import QCoreApplication, QObject, QSize
 from PySide6.QtWidgets import (
@@ -126,10 +127,9 @@ class ImportLevelWidget(QWidget):
         self.lne_import_level.setProperty("color", "on_surface")
         self.lne_import_level.setReadOnly(True)
 
-        self.btn_import_level = QIconButton(self.frm_import_level)
+        self.btn_import_level = AIconButton("folder.svg", self.frm_import_level)
         self.btn_import_level.setCheckable(True)
         self.btn_import_level.setFixedSize(QSize(27, 27))
-        self.btn_import_level.setIcon("folder.svg")
         self.btn_import_level.setIconSize(QSize(15, 15))
         self.btn_import_level.setProperty("backgroundColor", "primary")
 

--- a/src/amulet_editor/tools/startup/pages/_new_project.py
+++ b/src/amulet_editor/tools/startup/pages/_new_project.py
@@ -4,10 +4,10 @@ from typing import Callable, Optional
 
 from amulet_editor.data import packages, paths, project
 from amulet_editor.models.generic import Observer
+from amulet_editor.models.widgets import AIconButton
 from amulet_editor.tools.programs import Programs
 from amulet_editor.tools.project import Project
 from amulet_editor.tools.startup._models import Menu, Navigate, ProjectData
-from amulet_editor.tools.startup._widgets import QIconButton
 from amulet_editor.tools.startup.pages._import_level import ImportLevelMenu
 from PySide6.QtCore import QCoreApplication, QObject, QSize
 from PySide6.QtWidgets import (
@@ -103,9 +103,8 @@ class NewProjectWidget(QWidget):
         self.lne_project_directory.setProperty("color", "on_surface")
         self.lne_project_directory.setReadOnly(True)
 
-        self.btn_project_directory = QIconButton(self.frm_project_directory)
+        self.btn_project_directory = AIconButton("folder.svg", self.frm_project_directory)
         self.btn_project_directory.setFixedSize(QSize(27, 27))
-        self.btn_project_directory.setIcon("folder.svg")
         self.btn_project_directory.setIconSize(QSize(15, 15))
         self.btn_project_directory.setProperty("backgroundColor", "primary")
 

--- a/src/amulet_editor/tools/startup/pages/_open_world.py
+++ b/src/amulet_editor/tools/startup/pages/_open_world.py
@@ -6,10 +6,11 @@ import amulet
 from amulet_editor.data import packages, project
 from amulet_editor.models.generic import Observer
 from amulet_editor.models.minecraft import LevelData
+from amulet_editor.models.widgets import AIconButton
 from amulet_editor.tools.programs import Programs
 from amulet_editor.tools.project import Project
 from amulet_editor.tools.startup._models import Menu, Navigate
-from amulet_editor.tools.startup._widgets import QIconButton, QLevelSelectionCard
+from amulet_editor.tools.startup._widgets import QLevelSelectionCard
 from amulet_editor.tools.startup.panels._world_selection import WorldSelectionPanel
 from PySide6.QtCore import QCoreApplication, QObject, QSize
 from PySide6.QtWidgets import (
@@ -157,10 +158,9 @@ class OpenWorldWidget(QWidget):
         self.lne_level_directory.setProperty("color", "on_surface")
         self.lne_level_directory.setReadOnly(True)
 
-        self.btn_level_directory = QIconButton(self.frm_level_directory)
+        self.btn_level_directory = AIconButton("folder.svg", self.frm_level_directory)
         self.btn_level_directory.setCheckable(True)
         self.btn_level_directory.setFixedSize(QSize(27, 27))
-        self.btn_level_directory.setIcon("folder.svg")
         self.btn_level_directory.setIconSize(QSize(15, 15))
         self.btn_level_directory.setProperty("backgroundColor", "primary")
 

--- a/src/amulet_editor/tools/startup/pages/_select_packages.py
+++ b/src/amulet_editor/tools/startup/pages/_select_packages.py
@@ -1,4 +1,4 @@
-from amulet_editor.tools.startup._widgets import QIconButton
+from amulet_editor.models.widgets import AIconButton
 from PySide6.QtCore import QCoreApplication, QSize, Qt
 from PySide6.QtWidgets import (
     QFrame,
@@ -56,10 +56,9 @@ class SelectPackagesPage(QWidget):
         self.frm_project.setProperty("border", "surface")
         self.frm_project.setProperty("borderRadiusVisible", True)
 
-        self.btn_project = QIconButton(self.frm_project)
+        self.btn_project = AIconButton("adjustments-horizontal.svg", self.frm_project)
         self.btn_project.setEnabled(False)
         self.btn_project.setFixedSize(QSize(27, 27))
-        self.btn_project.setIcon("adjustments-horizontal.svg")
         self.btn_project.setIconSize(QSize(15, 15))
         self.btn_project.setProperty("backgroundColor", "primary")
 

--- a/src/amulet_editor/tools/startup/panels/_startup.py
+++ b/src/amulet_editor/tools/startup/panels/_startup.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from functools import partial
 
 from amulet_editor.data import build
-from amulet_editor.models.widgets import QLinkCard
+from amulet_editor.models.widgets import ALinkCard
 from PySide6.QtCore import QCoreApplication, Qt
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
@@ -61,7 +61,7 @@ class StartupPanel(QWidget):
 
         self.wgt_links.layout().addWidget(self.lbl_links)
         for link in links:
-            link_card = QLinkCard(
+            link_card = ALinkCard(
                 link.name, build.get_resource(f"icons/tabler/{link.icon}"), self.wgt_links
             )
             link_card.clicked.connect(partial(webbrowser.open, link.url))

--- a/src/amulet_editor/tools/startup/panels/_world_selection.py
+++ b/src/amulet_editor/tools/startup/panels/_world_selection.py
@@ -7,8 +7,7 @@ from typing import Optional
 import amulet
 from amulet_editor.data import build, minecraft
 from amulet_editor.models.minecraft import LevelData
-from amulet_editor.models.widgets import QPixCard
-from amulet_editor.tools.startup._widgets import QIconButton
+from amulet_editor.models.widgets import QPixCard, AIconButton
 from PySide6.QtCore import QCoreApplication, QObject, QSize, Qt, QThread, Signal, Slot
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
@@ -249,10 +248,9 @@ class WorldSelectionPanel(QWidget):
         self.lne_search_level.setProperty("borderRight", "surface")
         self.lne_search_level.setProperty("color", "on_surface")
 
-        self.btn_search_level = QIconButton(self.frm_search_level)
+        self.btn_search_level = AIconButton("adjustments-horizontal.svg", self.frm_search_level)
         self.btn_search_level.setCheckable(True)
         self.btn_search_level.setFixedSize(QSize(27, 27))
-        self.btn_search_level.setIcon("adjustments-horizontal.svg")
         self.btn_search_level.setIconSize(QSize(15, 15))
         self.btn_search_level.setProperty("backgroundColor", "primary")
 
@@ -301,9 +299,8 @@ class WorldSelectionPanel(QWidget):
         self.cbx_sort = QComboBox(self.wgt_search_options)
         self.cbx_sort.setFixedHeight(25)
 
-        self.btn_sort = QIconButton(self.frm_sort)
+        self.btn_sort = AIconButton("sort-descending.svg", self.frm_sort)
         self.btn_sort.setFixedSize(QSize(27, 27))
-        self.btn_sort.setIcon("sort-descending.svg")
         self.btn_sort.setIconSize(QSize(15, 15))
         self.btn_sort.setProperty("backgroundColor", "primary")
 


### PR DESCRIPTION
Refactored the SVG widget and button to allow styling via style sheets rather than code.
This will allow more flexibility to custom styles.
Depreciated QSvgIcon and both QIconButton classes.

Refactored and improved QDragContainer.
ADragContainer now uses the styleable svg button to make styling easier.
Improved drag behaviour. The widgets rearrange as you a dragging making the outcome more obvious.
