### PR TITLE
Switched ADragContainer inputs

### DIFF
--- a/src/amulet_editor/application/windows/_amulet_window.py
+++ b/src/amulet_editor/application/windows/_amulet_window.py
@@ -303,7 +303,7 @@ class AmuletWindow(QMainWindow):
         self.frm_static_tools.setFixedWidth(40)
 
         # Configure widget for 'Dynamic Menu' items
-        self.wgt_dynamic_tools = ADragContainer(parent=self.frm_static_tools)
+        self.wgt_dynamic_tools = ADragContainer(self.frm_static_tools)
         self.wgt_dynamic_tools.layout().setAlignment(Qt.AlignTop)
         self.wgt_dynamic_tools.layout().setContentsMargins(0, 0, 0, 0)
         self.wgt_dynamic_tools.layout().setSpacing(0)

--- a/src/amulet_editor/models/widgets/_draggable.py
+++ b/src/amulet_editor/models/widgets/_draggable.py
@@ -10,7 +10,7 @@ class ADragContainer(QWidget):
 
     # orderChanged = Signal(list)
 
-    def __init__(self, orientation: Qt.Orientation = Qt.Orientation.Vertical, parent: QWidget = None):
+    def __init__(self, parent: QWidget = None, orientation: Qt.Orientation = Qt.Orientation.Vertical):
         super().__init__(parent)
         self.setMouseTracking(True)
 


### PR DESCRIPTION
having parent first is more compatible with the base class and makes it play nicer with Qt Designer