### PR TITLE
Added an argument to trace function calls

### DIFF
--- a/src/amulet_editor/application/_app.py
+++ b/src/amulet_editor/application/_app.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import threading
 from typing import Optional
 import sys
 import os
@@ -74,6 +76,20 @@ def app_main():
     logging.basicConfig(
         level=args.logging_level, format=args.logging_format, force=True
     )
+
+    if args.trace:
+        def trace_calls(frame, event, arg):
+            if event == 'call':
+                try:
+                    func_name = frame.f_code.co_name
+                    module_name = frame.f_globals['__name__']
+                    logging.info(f"Call to {module_name}.{func_name}")
+                except AttributeError:
+                    pass
+            return trace_calls
+
+        sys.settrace(trace_calls)
+        threading.settrace(trace_calls)
 
     file_path = os.path.join(
         logging_directory(),

--- a/src/amulet_editor/application/_app.py
+++ b/src/amulet_editor/application/_app.py
@@ -78,11 +78,12 @@ def app_main():
     )
 
     if args.trace:
+
         def trace_calls(frame, event, arg):
-            if event == 'call':
+            if event == "call":
                 try:
                     func_name = frame.f_code.co_name
-                    module_name = frame.f_globals['__name__']
+                    module_name = frame.f_globals["__name__"]
                     logging.info(f"Call to {module_name}.{func_name}")
                 except AttributeError:
                     pass

--- a/src/amulet_editor/application/_cli.py
+++ b/src/amulet_editor/application/_cli.py
@@ -55,7 +55,7 @@ def parse_args() -> Args:
             "--trace",
             help="If defined, print the qualified name of each function as it is called. Useful if the program crashes due to an access violation and you don't know where it came from.",
             action="store_true",
-            dest="trace"
+            dest="trace",
         )
 
         _args, _ = parser.parse_known_args()

--- a/src/amulet_editor/application/_cli.py
+++ b/src/amulet_editor/application/_cli.py
@@ -12,6 +12,7 @@ class Args(Protocol):
     level_path: Optional[str]
     logging_level: int
     logging_format: str
+    trace: bool
 
 
 _args = None
@@ -50,6 +51,13 @@ def parse_args() -> Args:
             default="%(levelname)s - %(message)s",
         )
 
+        parser.add_argument(
+            "--trace",
+            help="If defined, print the qualified name of each function as it is called. Useful if the program crashes due to an access violation and you don't know where it came from.",
+            action="store_true",
+            dest="trace"
+        )
+
         _args, _ = parser.parse_known_args()
 
     return _args  # noqa
@@ -67,6 +75,8 @@ def spawn_process(path: str = None):
         "--logging_format",
         this_args.logging_format,
     ]
+    if this_args.trace:
+        new_args.append("--trace")
     subprocess.Popen(
         new_args,
         start_new_session=True,


### PR DESCRIPTION
PySide6 can be a bit unstable. If the wrong object is passed it will usually crash with an access violation rather than raising a python exception which makes finding the origin rather hard.
Adding the --trace command line argument will print the qualified name of each function as it is called. If the program hard crashes the last line should be the origin of the crash.