### PR TITLE
Fixed importing error if PyPI name does not match package name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ platforms = any
 
 [options]
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     PySide6~=6.2
     numpy~=1.17

--- a/src/amulet_editor/models/plugin/_requirement.py
+++ b/src/amulet_editor/models/plugin/_requirement.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import NamedTuple
 import re
 from packaging.specifiers import SpecifierSet
 
@@ -12,9 +11,20 @@ RequirementPattern = re.compile(
 )
 
 
-class Requirement(NamedTuple):
-    identifier: str  # The package name
-    specifier: SpecifierSet  # The version specifier. It is recommended to use the compatible format. Eg. "~=1.0"
+class Requirement:
+    def __init__(self, identifier: str, specifier: SpecifierSet):
+        self._identifier = identifier.lower().replace("-", "_")
+        self._specifier = specifier
+
+    @property
+    def identifier(self) -> str:
+        """The package name"""
+        return self._identifier
+
+    @property
+    def specifier(self) -> SpecifierSet:
+        """The version specifier. It is recommended to use the compatible format. Eg. "~=1.0"""
+        return self._specifier
 
     @classmethod
     def from_string(cls, requirement: str):

--- a/src/amulet_editor/models/plugin/_uid.py
+++ b/src/amulet_editor/models/plugin/_uid.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import NamedTuple
 import re
 
 from packaging.version import Version
@@ -8,11 +7,22 @@ from runtime_final import final
 
 
 @final
-class LibraryUID(NamedTuple):
+class LibraryUID:
     """A named tuple containing an identifier for a library/plugin and a version number."""
 
-    identifier: str  # The package name. This is the name used when importing the package. Eg "my_name_my_plugin_v1". This must be a valid python identifier.
-    version: Version  # The version number of the plugin.
+    def __init__(self, identifier: str, version: Version):
+        self._identifier = identifier.lower().replace("-", "_")
+        self._version = version
+
+    @property
+    def identifier(self) -> str:
+        """The package name. This is the name used when importing the package. Eg "my_name_my_plugin_v1". This must be a valid python identifier."""
+        return self._identifier
+
+    @property
+    def version(self) -> Version:
+        """The version number of the plugin."""
+        return self._version
 
     def to_string(self):
         return f"{self.identifier}@{self.version}"


### PR DESCRIPTION
In some cases (eg Pillow and PyOpenGL) the name of the package does not match the name of the package used to import it. This uses a function to find the PyPi name that a module came from. This requires Python 3.10 so the requirement is bumped.