### PR TITLE
Underscore package names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,11 @@ install_requires =
     numpy~=1.17
     pyopengl~=3.0
     packaging
-    amulet-core~=1.9
-    amulet-nbt~=2.0
+    amulet_core~=1.9
+    amulet_nbt~=2.0
     pymctranslate~=1.2
-    minecraft-resource-pack~=1.3
-    amulet-runtime-final~=1.1
+    minecraft_resource_pack~=1.3
+    amulet_runtime_final~=1.1
 
 package_dir=
     =src


### PR DESCRIPTION
The dash format is valid but this will make it easier to copy to places where only the underscore format is valid