### PR TITLE
Fix linux installer

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         pip install git+https://github.com/Amulet-Team/python-build-tool.git
         pip install --upgrade --upgrade-strategy eager -e .
-        pbt freeze
+        pbt freeze --debug
         pbt installer
 
     - name: Upload Release Asset

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Ubuntu dependencies
       if: matrix.cfg.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install ruby-dev build-essential
+        sudo apt-get install ruby-dev build-essential libegl1-mesa libegl1-mesa-dev
         sudo gem i fpm -f
 
     - name: Create Installer

--- a/src/amulet_editor/__pyinstaller/hook-OpenGL.py
+++ b/src/amulet_editor/__pyinstaller/hook-OpenGL.py
@@ -1,0 +1,7 @@
+from PyInstaller.utils.hooks import (
+    collect_submodules,
+)
+
+hiddenimports = [
+    *collect_submodules("OpenGL"),  # On my linux install not everything was included.
+]

--- a/src/amulet_editor/__pyinstaller/hook-PySide6.py
+++ b/src/amulet_editor/__pyinstaller/hook-PySide6.py
@@ -1,0 +1,9 @@
+import glob
+from PyInstaller.utils.hooks import (
+    collect_data_files,
+    collect_submodules,
+)
+
+hiddenimports = collect_submodules("PySide6")
+binaries = [(path, ".") for path in glob.glob("Qt/lib/*.so*")]
+datas = collect_data_files("PySide6", includes=["*.pyi", "py.typed"])

--- a/src/amulet_editor/__pyinstaller/hook-PySide6.py
+++ b/src/amulet_editor/__pyinstaller/hook-PySide6.py
@@ -1,11 +1,14 @@
 import glob
+import os
 from PyInstaller.utils.hooks import (
     collect_data_files,
     collect_submodules,
 )
 
+import PySide6
+
 hiddenimports = collect_submodules("PySide6")
 print("added qt libraries")
-print([(path, ".") for path in glob.glob("Qt/lib/*.so*")])
-binaries = [(path, ".") for path in glob.glob("Qt/lib/*.so*")]
+binaries = [(path, ".") for path in glob.glob(os.path.join(glob.escape(PySide6.__path__[0]), "Qt", "lib", "*.so*"))]
+print(binaries)
 datas = collect_data_files("PySide6", includes=["*.pyi", "py.typed"])

--- a/src/amulet_editor/__pyinstaller/hook-PySide6.py
+++ b/src/amulet_editor/__pyinstaller/hook-PySide6.py
@@ -8,5 +8,10 @@ from PyInstaller.utils.hooks import (
 import PySide6
 
 hiddenimports = collect_submodules("PySide6")
-binaries = [(path, ".") for path in glob.glob(os.path.join(glob.escape(PySide6.__path__[0]), "Qt", "lib", "*.so*"))]
+binaries = [
+    (path, ".")
+    for path in glob.glob(
+        os.path.join(glob.escape(PySide6.__path__[0]), "Qt", "lib", "*.so*")
+    )
+]
 datas = collect_data_files("PySide6", includes=["*.pyi", "py.typed"])

--- a/src/amulet_editor/__pyinstaller/hook-PySide6.py
+++ b/src/amulet_editor/__pyinstaller/hook-PySide6.py
@@ -8,7 +8,5 @@ from PyInstaller.utils.hooks import (
 import PySide6
 
 hiddenimports = collect_submodules("PySide6")
-print("added qt libraries")
 binaries = [(path, ".") for path in glob.glob(os.path.join(glob.escape(PySide6.__path__[0]), "Qt", "lib", "*.so*"))]
-print(binaries)
 datas = collect_data_files("PySide6", includes=["*.pyi", "py.typed"])

--- a/src/amulet_editor/__pyinstaller/hook-PySide6.py
+++ b/src/amulet_editor/__pyinstaller/hook-PySide6.py
@@ -5,5 +5,7 @@ from PyInstaller.utils.hooks import (
 )
 
 hiddenimports = collect_submodules("PySide6")
+print("added qt libraries")
+print([(path, ".") for path in glob.glob("Qt/lib/*.so*")])
 binaries = [(path, ".") for path in glob.glob("Qt/lib/*.so*")]
 datas = collect_data_files("PySide6", includes=["*.pyi", "py.typed"])

--- a/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
+++ b/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
@@ -14,9 +14,6 @@ datas = [
     *copy_metadata("amulet_editor", recursive=True),
 ]
 
-print("hidden")
-print(collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"))
-
 hiddenimports = [
     *collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"),
     "PySide6",

--- a/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
+++ b/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
@@ -1,16 +1,10 @@
-try:
-    from PyInstaller.utils.hooks import (
-        collect_data_files,
-        copy_metadata,
-        collect_submodules,
-    )
-except ImportError as e:
-    raise ImportError(
-        "This is part of the build pipeline. It cannot be imported at runtime."
-    ) from e
+from PyInstaller.utils.hooks import (
+    collect_data_files,
+    copy_metadata,
+    collect_submodules,
+)
 
 datas = [
-    *collect_data_files("PySide6", includes=["*.pyi", "py.typed"]),
     *collect_data_files("amulet_editor", excludes=["**/*.ui", "**/*.c", "**/*.pyx"]),
     *collect_data_files(
         "amulet_editor.plugins",
@@ -22,6 +16,6 @@ datas = [
 
 hiddenimports = [
     *collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"),
-    *collect_submodules("PySide6"),
-    *collect_submodules("OpenGL"),  # On my linux install not everything was included.
+    "PySide6",
+    "OpenGL"
 ]

--- a/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
+++ b/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
@@ -14,6 +14,9 @@ datas = [
     *copy_metadata("amulet_editor", recursive=True),
 ]
 
+print("hidden")
+print(collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"))
+
 hiddenimports = [
     *collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"),
     "PySide6",

--- a/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
+++ b/src/amulet_editor/__pyinstaller/hook-amulet_editor.py
@@ -17,5 +17,5 @@ datas = [
 hiddenimports = [
     *collect_submodules("amulet_editor", lambda name: name != "amulet_editor.plugins"),
     "PySide6",
-    "OpenGL"
+    "OpenGL",
 ]


### PR DESCRIPTION
Adds missing `.so` files that were not included by the normal PyInstaller hook.
Fixed build time exception that was stopping python modules being included due to libEGL being missing.