### PR TITLE
Refactored plugin hooks

### DIFF
--- a/src/amulet_editor/models/plugin/__init__.py
+++ b/src/amulet_editor/models/plugin/__init__.py
@@ -1,2 +1,3 @@
+from ._plugin import PluginV1
 from ._uid import LibraryUID
 from ._data import PluginData, PluginDataDepends

--- a/src/amulet_editor/models/plugin/_container.py
+++ b/src/amulet_editor/models/plugin/_container.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
 from amulet_editor.data.paths._plugin import first_party_plugin_directory
+from ._plugin import PluginV1
 from ._data import PluginData, PluginDataDepends
 from ._state import PluginState
 from ._requirement import Requirement
@@ -39,6 +40,7 @@ class Plugin(Protocol):
 class PluginContainer(ABC):
     data: PluginData
     instance: Optional[Plugin]  # The instance of the plugin.
+    plugin: Optional[PluginV1]
     state: PluginState
 
     FormatVersion: int = None
@@ -46,6 +48,7 @@ class PluginContainer(ABC):
     def __init__(self, data: PluginData):
         self.data = data
         self.instance = None
+        self.plugin = None
         self.state = PluginState.Disabled
 
     @classmethod

--- a/src/amulet_editor/models/plugin/_plugin.py
+++ b/src/amulet_editor/models/plugin/_plugin.py
@@ -1,0 +1,6 @@
+from typing import Callable, NamedTuple
+
+
+class PluginV1(NamedTuple):
+    load: Callable[[], None] = lambda: None
+    unload: Callable[[], None] = lambda: None

--- a/src/amulet_editor/plugins/amulet_team_3d_viewer/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_3d_viewer/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin, unload_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_3d_viewer/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_3d_viewer/_plugin.py
@@ -5,6 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QLocale, QCoreApplication
 
 from amulet_editor.models.localisation import ATranslator
+from amulet_editor.models.plugin import PluginV1
 
 import amulet_team_locale
 
@@ -33,3 +34,6 @@ def _locale_changed():
 
 def unload_plugin():
     QCoreApplication.removeTranslator(_translator)
+
+
+plugin = PluginV1(load_plugin, unload_plugin)

--- a/src/amulet_editor/plugins/amulet_team_home_page/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_home_page/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin, unload_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_home_page/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_home_page/_plugin.py
@@ -5,6 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QLocale, QCoreApplication
 
 from amulet_editor.models.localisation import ATranslator
+from amulet_editor.models.plugin import PluginV1
 
 import amulet_team_locale
 
@@ -45,3 +46,6 @@ def _locale_changed():
 def unload_plugin():
     unregister_view(HomeView)
     QCoreApplication.removeTranslator(_translator)
+
+
+plugin = PluginV1(load_plugin, unload_plugin)

--- a/src/amulet_editor/plugins/amulet_team_layout/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_layout/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin, unload_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_layout/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_layout/_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from amulet_editor.data.project import get_level
+from amulet_editor.models.plugin import PluginV1
 
 
 from amulet_team_main_window.api import (
@@ -20,3 +21,6 @@ def load_plugin():
 
 def unload_plugin():
     unregister_view(View3D)
+
+
+plugin = PluginV1(load_plugin, unload_plugin)

--- a/src/amulet_editor/plugins/amulet_team_locale/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_locale/__init__.py
@@ -1,6 +1,10 @@
 from amulet_editor.data._localisation import set_locale, locale_changed  # noqa
+from amulet_editor.models.plugin import PluginV1
 
 
 def load_plugin():
     # TODO: load locale this from a config file
     pass
+
+
+plugin = PluginV1(load_plugin)

--- a/src/amulet_editor/plugins/amulet_team_main_window/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_main_window/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_main_window/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_main_window/_plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Optional
 
 from amulet_team_main_window.application.windows.main_window import AmuletMainWindow
+from amulet_editor.models.plugin import PluginV1
 
 
 window: Optional[AmuletMainWindow] = None
@@ -11,3 +12,6 @@ def load_plugin():
     global window
     window = AmuletMainWindow()
     window.showMaximized()
+
+
+plugin = PluginV1(load_plugin)

--- a/src/amulet_editor/plugins/amulet_team_main_window2/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_main_window2/__init__.py
@@ -1,1 +1,1 @@
-# from ._plugin import load_plugin
+# from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_main_window2/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_main_window2/_plugin.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from typing import Optional
 
-from .application.windows.main_window import AmuletMainWindow
+from amulet_team_main_window2.application.windows.main_window import AmuletMainWindow
+from amulet_editor.models.plugin import PluginV1
 
 
 window: Optional[AmuletMainWindow] = None
@@ -11,3 +12,6 @@ def load_plugin():
     global window
     window = AmuletMainWindow()
     window.showMaximized()
+
+
+plugin = PluginV1(load_plugin)

--- a/src/amulet_editor/plugins/amulet_team_resource_pack/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_resource_pack/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin, unload_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_resource_pack/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_resource_pack/_plugin.py
@@ -5,6 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QLocale, QCoreApplication
 
 from amulet_editor.models.localisation import ATranslator
+from amulet_editor.models.plugin import PluginV1
 
 import amulet_team_locale
 
@@ -35,3 +36,6 @@ def _locale_changed():
 
 def unload_plugin():
     QCoreApplication.removeTranslator(_translator)
+
+
+plugin = PluginV1(load_plugin, unload_plugin)

--- a/src/amulet_editor/plugins/amulet_team_settings/__init__.py
+++ b/src/amulet_editor/plugins/amulet_team_settings/__init__.py
@@ -1,1 +1,1 @@
-from ._plugin import load_plugin
+from ._plugin import plugin

--- a/src/amulet_editor/plugins/amulet_team_settings/_plugin.py
+++ b/src/amulet_editor/plugins/amulet_team_settings/_plugin.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt
 
+from amulet_editor.models.plugin import PluginV1
+
 from .settings import SettingsPage
 
 from amulet_team_main_window.api import add_static_toolbar_button
@@ -21,3 +23,6 @@ def _on_click(self):
     settings.setWindowModality(Qt.WindowModality.ApplicationModal)
     settings.showNormal()
     self._windows.append(settings)
+
+
+plugin = PluginV1(load_plugin)

--- a/src/amulet_editor/plugins/amulet_team_settings/plugin.json
+++ b/src/amulet_editor/plugins/amulet_team_settings/plugin.json
@@ -8,7 +8,8 @@
 			"amulet_team_main_window~=1.0"
 		],
 		"library": [
-			"PySide6_Essentials~=6.2"
+			"PySide6_Essentials~=6.2",
+			"amulet_editor~=1.0a0"
 		]
 	},
 	"locked": "true"


### PR DESCRIPTION
Plugin hooks were previously global in the root module of the plugin.
If we wanted to change the hook format it would have been quite difficult.
This changes the plugin format so that there is one root attribute called `plugin` which is an instance of PluginV1.
If we want to change the hook format in the future we can implement another class while still supporting the old format.