### PR TITLE
Switch to a git commit reference for Amulet Core

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -24,7 +24,6 @@ jobs:
 
     steps:
     - name: Configure Git
-      shell: bash
       run: |
         git config --global core.longpaths true
     - uses: actions/checkout@v3
@@ -56,6 +55,11 @@ jobs:
 
     - name: Create Installer
       run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          export TMPDIR="C:\temp"
+          export TMP="C:\temp"
+          export TEMP="C:\temp"
+        fi
         pip install git+https://github.com/Amulet-Team/python-build-tool.git
         pip install --upgrade --upgrade-strategy eager -e .
         pbt freeze --debug

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -23,6 +23,10 @@ jobs:
         - {os: ubuntu-latest, python-version: '3.12', architecture: x64}
 
     steps:
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global core.longpaths true
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.cfg.python-version }} ${{ matrix.cfg.architecture }}
       uses: actions/setup-python@v4

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -21,6 +21,10 @@ jobs:
         python-version: ['3.11', '3.12']
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global core.longpaths true
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -21,22 +21,23 @@ jobs:
         python-version: ['3.11', '3.12']
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-    - name: Configure Paths
+    - name: Configure Git
       shell: bash
       run: |
         git config --global core.longpaths true
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          export TMPDIR="C:\temp"
-          export TMP="C:\temp"
-          export TEMP="C:\temp"
-        fi
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: bash
       run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          export TMPDIR="C:\temp"
+          export TMP="C:\temp"
+          export TEMP="C:\temp"
+        fi
         python -m pip install --upgrade pip
         pip install -e .
     - name: Test with unittest

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -21,10 +21,13 @@ jobs:
         python-version: ['3.11', '3.12']
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-    - name: Configure Git
+    - name: Configure Paths
       shell: bash
       run: |
         git config --global core.longpaths true
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          export TMPDIR="C:\temp"
+        fi
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -27,6 +27,8 @@ jobs:
         git config --global core.longpaths true
         if [ "$RUNNER_OS" == "Windows" ]; then
           export TMPDIR="C:\temp"
+          export TMP="C:\temp"
+          export TEMP="C:\temp"
         fi
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   unittests:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +26,6 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
     - name: Configure Git
-      shell: bash
       run: |
         git config --global core.longpaths true
     - uses: actions/checkout@v2
@@ -31,7 +34,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           export TMPDIR="C:\temp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = [
     "versioneer",
     "pybind11 ~= 2.12",
     "amulet_nbt ~= 4.0a2",
-    "amulet_core == 2.0a8"
+    "amulet_core @ git+https://github.com/Amulet-Team/Amulet-Core.git@7844bec50b93c8711ae703840b1a0e43b8283df6"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     pyopengl~=3.0
     packaging
     amulet_nbt~=4.0a2
-    amulet_core==2.0a8
+    amulet_core @ git+https://github.com/Amulet-Team/Amulet-Core.git@7844bec50b93c8711ae703840b1a0e43b8283df6
     amulet_runtime_final~=1.1
     Pillow
 


### PR DESCRIPTION
The core library is changing frequently in ways that are not tied to a semantic version.
Instead of creating a release for each change the repo can be referenced directly.

This also exposed some path length issues on Windows which I have worked around by setting the temporary directory.