### PR TITLE
Revert translator changes

### DIFF
--- a/src/amulet/app/localisation/_translator.py
+++ b/src/amulet/app/localisation/_translator.py
@@ -60,7 +60,7 @@ class Translator(QTranslator):
         source_text: str,
         disambiguation: str | None = None,
         n: int = -1,
-    ) -> str:
+    ) -> str | None:
         return super().translate(
             context, source_text, disambiguation, n
-        ) or self._translations.get(f"{context}.{source_text}", "")
+        ) or self._translations.get(f"{context}.{source_text}", None)

--- a/tools/patch_pyside6_stubs.py
+++ b/tools/patch_pyside6_stubs.py
@@ -6,6 +6,11 @@ PySide6Path = PySide6.__path__[0]
 Patches: dict[str, list[tuple[str, str]]] = {
     os.path.join(PySide6Path, "QtCore.pyi"): [
         (
+            # QTranslator
+            "def translate(self, context: str, sourceText: str, /, disambiguation: str | None = ..., n: int = ...) -> str: ...",
+            "def translate(self, context: str, sourceText: str, /, disambiguation: str | None = ..., n: int = ...) -> str | None: ...",
+        ),
+        (
             # QByteArray
             "def data(self, /) -> bytes | bytearray | memoryview: ...",
             "def data(self) -> bytes: ...",


### PR DESCRIPTION
QTranslator::translate can return None but this is missing from the type hints.
Fix stub patcher