### PR TITLE
Synchronise camera state across viewports

### DIFF
--- a/src/builtin_plugins/plugin/amulet/camera/__init__.py
+++ b/src/builtin_plugins/plugin/amulet/camera/__init__.py
@@ -1,0 +1,1 @@
+from ._camera import CameraExtrinsics, Location, Rotation, get_camera_extrinsics

--- a/src/builtin_plugins/plugin/amulet/camera/_camera.py
+++ b/src/builtin_plugins/plugin/amulet/camera/_camera.py
@@ -40,6 +40,7 @@ class CameraExtrinsics(QObject):
 
     # Private variables
     _bounds: Bounds
+    _speed: float
     # Extrinsic attrs
     _location: Location
     _rotation: Rotation
@@ -48,6 +49,7 @@ class CameraExtrinsics(QObject):
 
     __slots__ = (
         "_bounds",
+        "_speed",
         "_location",
         "_rotation",
         "_extrinsic_matrix",
@@ -63,8 +65,9 @@ class CameraExtrinsics(QObject):
             1_000_000_000,
             1_000_000_000,
         )
-        self._location = None
-        self._rotation = None
+        self._speed = 1.0
+        self._location = location
+        self._rotation = rotation
         self._matrix = None
 
     def _clamp_location(self, location: Location) -> Location:
@@ -73,6 +76,15 @@ class CameraExtrinsics(QObject):
             min(max(self._bounds.min_y, location.y), self._bounds.max_y),
             min(max(self._bounds.min_z, location.z), self._bounds.max_z),
         )
+
+    @property
+    def speed(self) -> float:
+        """The speed of the camera in blocks per second."""
+        return self._speed
+
+    @speed.setter
+    def speed(self, speed: float) -> None:
+        self._speed = speed
 
     @property
     def location(self) -> Location:

--- a/src/builtin_plugins/plugin/amulet/camera/_camera.py
+++ b/src/builtin_plugins/plugin/amulet/camera/_camera.py
@@ -1,0 +1,170 @@
+from typing import NamedTuple, Optional
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtGui import QMatrix4x4
+
+
+class Location(NamedTuple):
+    x: float
+    y: float
+    z: float
+
+
+class Rotation(NamedTuple):
+    azimuth: float
+    elevation: float
+
+
+class Bounds(NamedTuple):
+    min_x: float
+    min_y: float
+    min_z: float
+    max_x: float
+    max_y: float
+    max_z: float
+
+
+class CameraExtrinsics(QObject):
+    """
+    A class to hold the camera extrinsic state.
+    Note that this class is not thread safe.
+    All operations must be called from the main thread.
+    """
+
+    # Signals
+    # The matrix changed.
+    transform_changed = Signal()
+    # The camera moved
+    location_changed = Signal()
+    # The camera rotated
+    rotation_changed = Signal()
+
+    # Private variables
+    _bounds: Bounds
+    # Extrinsic attrs
+    _location: Location
+    _rotation: Rotation
+    # Matrix
+    _matrix: Optional[QMatrix4x4]
+
+    __slots__ = (
+        "_bounds",
+        "_location",
+        "_rotation",
+        "_extrinsic_matrix",
+    )
+
+    def __init__(self, location: Location, rotation: Rotation) -> None:
+        super().__init__()
+        self._bounds = Bounds(
+            -1_000_000_000,
+            -1_000_000_000,
+            -1_000_000_000,
+            1_000_000_000,
+            1_000_000_000,
+            1_000_000_000,
+        )
+        self._location = None
+        self._rotation = None
+        self._matrix = None
+
+    def _clamp_location(self, location: Location) -> Location:
+        return Location(
+            min(max(self._bounds.min_x, location.x), self._bounds.max_x),
+            min(max(self._bounds.min_y, location.y), self._bounds.max_y),
+            min(max(self._bounds.min_z, location.z), self._bounds.max_z),
+        )
+
+    @property
+    def location(self) -> Location:
+        """The location of the camera. (x, y, z)"""
+        return self._location or Location(0.0, 0.0, 0.0)
+
+    @location.setter
+    def location(self, location: Location) -> None:
+        """Set the location of the camera. (x, y, z)."""
+
+        # Clamp location to the bounds.
+        location = self._clamp_location(location)
+
+        if location != self._location:
+            self._location = location
+            self._matrix = None
+            self.location_changed.emit()
+            self.transform_changed.emit()
+
+    def _clamp_rotation(self, rotation: Rotation) -> Rotation:
+        return Rotation(
+            (
+                rotation.azimuth
+                if -180 <= rotation.azimuth < 180
+                else ((rotation.azimuth + 180) % 360) - 180
+            ),
+            min(max(-90.0, rotation.elevation), 90.0),
+        )
+
+    @property
+    def rotation(self) -> Rotation:
+        """The rotation of the camera. (azimuth/yaw, elevation/pitch).
+        This should behave the same as how Minecraft handles it.
+        """
+        return self._rotation or Rotation(0.0, 0.0)
+
+    @rotation.setter
+    def rotation(self, rotation: Rotation) -> None:
+        """Set the rotation of the camera. (azimuth/yaw, elevation/pitch).
+        azimuth (-180 to 180), elevation (-90 to 90)
+        This should behave the same as how Minecraft handles it."""
+
+        # Clamp rotation to the bounds
+        rotation = self._clamp_rotation(rotation)
+
+        if rotation != self._rotation:
+            self._rotation = rotation
+            self._matrix = None
+            self.rotation_changed.emit()
+            self.transform_changed.emit()
+
+    def set_extrinsics(self, location: Location, rotation: Rotation) -> None:
+        """Set the camera location and rotation at the same time."""
+        location = self._clamp_location(location)
+        rotation = self._clamp_rotation(rotation)
+        location_changed = location != self._location
+        rotation_changed = rotation != self._rotation
+
+        if location_changed:
+            self._location = location
+        if rotation_changed:
+            self._rotation = rotation
+
+        if location_changed or rotation_changed:
+            self._matrix = None
+
+            if location_changed:
+                self.location_changed.emit()
+
+            if rotation_changed:
+                self.rotation_changed.emit()
+
+            self.transform_changed.emit()
+
+    @property
+    def matrix(self) -> QMatrix4x4:
+        """The matrix storing all extrinsic parameters (location/rotation)"""
+        if self._matrix is None:
+            self._matrix = QMatrix4x4()
+            location = self.location
+            rotation = self.rotation
+            self._matrix.rotate(rotation.elevation, 1, 0, 0)
+            self._matrix.rotate(rotation.azimuth, 0, 1, 0)
+            self._matrix.translate(-location.x, -location.y, -location.z)
+        return self._matrix
+
+
+_camera: CameraExtrinsics | None = None
+
+
+def get_camera_extrinsics(default_location: Location, default_rotation: Rotation) -> CameraExtrinsics:
+    global _camera
+    if _camera is None:
+        _camera = CameraExtrinsics(default_location, default_rotation)
+    return _camera

--- a/src/builtin_plugins/plugin/amulet/camera/_camera.py
+++ b/src/builtin_plugins/plugin/amulet/camera/_camera.py
@@ -175,7 +175,9 @@ class CameraExtrinsics(QObject):
 _camera: CameraExtrinsics | None = None
 
 
-def get_camera_extrinsics(default_location: Location, default_rotation: Rotation) -> CameraExtrinsics:
+def get_camera_extrinsics(
+    default_location: Location, default_rotation: Rotation
+) -> CameraExtrinsics:
     global _camera
     if _camera is None:
         _camera = CameraExtrinsics(default_location, default_rotation)

--- a/src/builtin_plugins/plugin/amulet/camera/plugin.json
+++ b/src/builtin_plugins/plugin/amulet/camera/plugin.json
@@ -1,0 +1,14 @@
+{
+	"namespace": "amulet",
+	"identifier": "camera",
+	"version": "1.0.0",
+	"name": "Amulet Camera",
+	"depends": {
+		"python": "~=3.11",
+		"library": [
+			"PySide6_Essentials~=6.2"
+		],
+		"plugin": []
+	},
+	"locked": "true"
+}

--- a/src/builtin_plugins/plugin/amulet/editor/plugin.json
+++ b/src/builtin_plugins/plugin/amulet/editor/plugin.json
@@ -23,7 +23,8 @@
 			"amulet.selection~=1.0",
 			"amulet.inspector~=1.0",
 			"amulet.resource_pack~=1.0",
-			"amulet.level~=1.0"
+			"amulet.level~=1.0",
+			"amulet.camera~=1.0"
 		]
 	},
 	"locked": "true"

--- a/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_camera.py
+++ b/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_camera.py
@@ -38,6 +38,15 @@ class Camera(QObject):
         self._extrinsics.transform_changed.connect(self.transform_changed)
 
     @property
+    def speed(self) -> float:
+        """The speed of the camera in blocks per second."""
+        return self._extrinsics.speed
+
+    @speed.setter
+    def speed(self, speed: float) -> None:
+        self._extrinsics.speed = speed
+
+    @property
     def location(self) -> Location:
         """The location of the camera. (x, y, z)"""
         return self._extrinsics.location

--- a/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_camera.py
+++ b/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_camera.py
@@ -1,26 +1,7 @@
-from typing import NamedTuple, Optional
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QMatrix4x4
 
-
-class Location(NamedTuple):
-    x: float
-    y: float
-    z: float
-
-
-class Rotation(NamedTuple):
-    azimuth: float
-    elevation: float
-
-
-class Bounds(NamedTuple):
-    min_x: float
-    min_y: float
-    min_z: float
-    max_x: float
-    max_y: float
-    max_z: float
+from plugin.amulet.camera import CameraExtrinsics, Location, Rotation
 
 
 class Camera(QObject):
@@ -38,121 +19,51 @@ class Camera(QObject):
     # The camera rotated
     rotation_changed = Signal()
 
-    # Private variables
-    _bounds: Bounds
-    # Extrinsic attrs
-    _location: Optional[Location]
-    _rotation: Optional[Rotation]
-    # Matrix
+    _extrinsics: CameraExtrinsics
     _intrinsic_matrix: QMatrix4x4
-    _extrinsic_matrix: Optional[QMatrix4x4]
 
     __slots__ = (
-        "_bounds",
-        "_location",
-        "_rotation",
         "_intrinsic_matrix",
-        "_extrinsic_matrix",
+        "_extrinsics",
     )
 
-    def __init__(self, parent: QObject | None = None) -> None:
-        super().__init__(parent)
-        self._bounds = Bounds(
-            -1_000_000_000,
-            -1_000_000_000,
-            -1_000_000_000,
-            1_000_000_000,
-            1_000_000_000,
-            1_000_000_000,
-        )
-        self._location = None
-        self._rotation = None
-
+    def __init__(self, camera_extrinsics: CameraExtrinsics) -> None:
+        super().__init__()
+        self._extrinsics = camera_extrinsics
         self._intrinsic_matrix = QMatrix4x4()
-        self._extrinsic_matrix = None
 
-    def _clamp_location(self, location: Location) -> Location:
-        return Location(
-            min(max(self._bounds.min_x, location.x), self._bounds.max_x),
-            min(max(self._bounds.min_y, location.y), self._bounds.max_y),
-            min(max(self._bounds.min_z, location.z), self._bounds.max_z),
-        )
+        self._extrinsics.location_changed.connect(self.location_changed)
+        self._extrinsics.rotation_changed.connect(self.rotation_changed)
+        self._extrinsics.transform_changed.connect(self.extrinsics_changed)
+        self._extrinsics.transform_changed.connect(self.transform_changed)
 
     @property
     def location(self) -> Location:
         """The location of the camera. (x, y, z)"""
-        return self._location or Location(0.0, 0.0, 0.0)
+        return self._extrinsics.location
 
     @location.setter
     def location(self, location: Location) -> None:
         """Set the location of the camera. (x, y, z)."""
-
-        # Clamp location to the bounds.
-        location = self._clamp_location(location)
-
-        if location != self._location:
-            self._location = location
-            self._extrinsic_matrix = None
-            self.location_changed.emit()
-            self.extrinsics_changed.emit()
-            self.transform_changed.emit()
-
-    def _clamp_rotation(self, rotation: Rotation) -> Rotation:
-        return Rotation(
-            (
-                rotation.azimuth
-                if -180 <= rotation.azimuth < 180
-                else ((rotation.azimuth + 180) % 360) - 180
-            ),
-            min(max(-90.0, rotation.elevation), 90.0),
-        )
+        self._extrinsics.location = location
 
     @property
     def rotation(self) -> Rotation:
         """The rotation of the camera. (azimuth/yaw, elevation/pitch).
         This should behave the same as how Minecraft handles it.
         """
-        return self._rotation or Rotation(0.0, 0.0)
+        return self._extrinsics.rotation
 
     @rotation.setter
     def rotation(self, rotation: Rotation) -> None:
         """Set the rotation of the camera. (azimuth/yaw, elevation/pitch).
         azimuth (-180 to 180), elevation (-90 to 90)
         This should behave the same as how Minecraft handles it."""
-
-        # Clamp rotation to the bounds
-        rotation = self._clamp_rotation(rotation)
-
-        if rotation != self._rotation:
-            self._rotation = rotation
-            self._extrinsic_matrix = None
-            self.rotation_changed.emit()
-            self.extrinsics_changed.emit()
-            self.transform_changed.emit()
+        self._extrinsics.rotation = rotation
 
     def set_extrinsics(self, location: Location, rotation: Rotation) -> None:
         """Set the camera location and rotation in one property."""
-        location = self._clamp_location(location)
-        rotation = self._clamp_rotation(rotation)
-        location_changed = location != self._location
-        rotation_changed = rotation != self._rotation
-
-        if location_changed:
-            self._location = location
-        if rotation_changed:
-            self._rotation = rotation
-
-        if location_changed or rotation_changed:
-            self._extrinsic_matrix = None
-
-            if location_changed:
-                self.location_changed.emit()
-
-            if rotation_changed:
-                self.rotation_changed.emit()
-
-            self.extrinsics_changed.emit()
-            self.transform_changed.emit()
+        self._extrinsics.set_extrinsics(location, rotation)
 
     def set_perspective_projection(
         self,
@@ -192,11 +103,4 @@ class Camera(QObject):
     @property
     def extrinsic_matrix(self) -> QMatrix4x4:
         """The matrix storing all extrinsic parameters (location/rotation)"""
-        if self._extrinsic_matrix is None:
-            self._extrinsic_matrix = QMatrix4x4()
-            location = self.location
-            rotation = self.rotation
-            self._extrinsic_matrix.rotate(rotation.elevation, 1, 0, 0)
-            self._extrinsic_matrix.rotate(rotation.azimuth, 0, 1, 0)
-            self._extrinsic_matrix.translate(-location.x, -location.y, -location.z)
-        return self._extrinsic_matrix
+        return self._extrinsics.matrix

--- a/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
+++ b/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
@@ -206,7 +206,6 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
         self._camera = Camera(get_camera_extrinsics(Location(0, 80, 0), Rotation(0, 90)))
         self._start_pos = QPoint()
         self._right_clicked = False
-        self._speed = 1.0
 
         self._key_catcher = KeyCatcher()
         self.installEventFilter(self._key_catcher)
@@ -490,7 +489,7 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
         x, y, z = self.camera.location
         azimuth = radians(self.camera.rotation.azimuth + angle)
         self.camera.location = Location(
-            x - sin(azimuth) * self._speed * dt, y, z + cos(azimuth) * self._speed * dt
+            x - sin(azimuth) * self.camera.speed * dt, y, z + cos(azimuth) * self.camera.speed * dt
         )
 
     @Slot()
@@ -512,17 +511,17 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
     @Slot()
     def _up(self, dt: float) -> None:
         x, y, z = self.camera.location
-        self.camera.location = Location(x, y + self._speed * dt, z)
+        self.camera.location = Location(x, y + self.camera.speed * dt, z)
 
     @Slot()
     def _down(self, dt: float) -> None:
         x, y, z = self.camera.location
-        self.camera.location = Location(x, y - self._speed * dt, z)
+        self.camera.location = Location(x, y - self.camera.speed * dt, z)
 
     @Slot()
     def _faster(self) -> None:
-        self._speed *= 1.1
+        self.camera.speed *= 1.1
 
     @Slot()
     def _slower(self) -> None:
-        self._speed /= 1.1
+        self.camera.speed /= 1.1

--- a/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
+++ b/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
@@ -203,7 +203,9 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
         self._level = level
         self._canvas_gl_data = CanvasGlData(self._level)
 
-        self._camera = Camera(get_camera_extrinsics(Location(0, 80, 0), Rotation(0, 90)))
+        self._camera = Camera(
+            get_camera_extrinsics(Location(0, 80, 0), Rotation(0, 90))
+        )
         self._start_pos = QPoint()
         self._right_clicked = False
 
@@ -489,7 +491,9 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
         x, y, z = self.camera.location
         azimuth = radians(self.camera.rotation.azimuth + angle)
         self.camera.location = Location(
-            x - sin(azimuth) * self.camera.speed * dt, y, z + cos(azimuth) * self.camera.speed * dt
+            x - sin(azimuth) * self.camera.speed * dt,
+            y,
+            z + cos(azimuth) * self.camera.speed * dt,
         )
 
     @Slot()

--- a/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
+++ b/src/builtin_plugins/plugin/amulet/editor/widget/_view_3d/_view_3d/_canvas.py
@@ -40,9 +40,10 @@ from amulet.app.qt.signal import Signal
 from plugin.amulet.resource_pack import get_resource_pack_handle
 
 from plugin.amulet.level import get_main_level
+from plugin.amulet.camera import get_camera_extrinsics, Location, Rotation
 
 from ._settings import render_settings
-from ._camera import Camera, Location, Rotation
+from ._camera import Camera
 from ._key_catcher import KeySrc, KeyCatcher
 
 from .level.level_geometry import LevelGeometry
@@ -202,9 +203,7 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
         self._level = level
         self._canvas_gl_data = CanvasGlData(self._level)
 
-        self._camera = Camera()
-        self.camera.transform_changed.connect(self.update)
-        self.camera.location_changed.connect(self._on_move)
+        self._camera = Camera(get_camera_extrinsics(Location(0, 80, 0), Rotation(0, 90)))
         self._start_pos = QPoint()
         self._right_clicked = False
         self._speed = 1.0
@@ -281,8 +280,6 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
             # Set the start position after OpenGL has been initialised
             # gl_data.render_level.set_dimension(next(iter(self._level.dimension_ids())))
             self._canvas_gl_data.render_level.set_dimension("minecraft:overworld")
-            self.camera.location = Location(0, 80, 0)
-            self.camera.rotation = Rotation(0, 90)
             self._initialised = True
             log.debug(f"FirstPersonCanvas.initializeGL({self}) end")
 
@@ -368,6 +365,11 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
             if not self._initialised:
                 return
 
+            # Update the chunk load position when the camera moves
+            self.camera.location_changed.connect(self._on_move)
+            # Repaint when the camera transform changes
+            self.camera.transform_changed.connect(self.update)
+
             # Repaint every time the geometry changes
             self._canvas_gl_data.geometry_changed.connect(self.update)
 
@@ -384,11 +386,18 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
             self._queue_load_resource_pack()
             log.debug("FirstPersonCanvas.showEvent end")
 
+            self._on_move()
+            self.update()
+
     def hideEvent(self, event: QHideEvent) -> None:
         with CatchExceptionDialog("Error hiding canvas."):
             log.debug(f"FirstPersonCanvas.hideEvent({self})")
             if not self._initialised:
                 return
+
+            # Disconnect from camera events
+            self.camera.transform_changed.disconnect(self.update)
+            self.camera.location_changed.disconnect(self._on_move)
 
             # Disconnect from the geometry changed event
             self._canvas_gl_data.geometry_changed.disconnect(self.update)
@@ -438,7 +447,7 @@ class FirstPersonCanvas(QOpenGLWidget, QOpenGLFunctions):
     def resizeGL(self, width: float, height: float) -> None:
         """Private resize method called by the QOpenGLWidget"""
         log.debug(f"FirstPersonCanvas.resizeGL({self}, {width}, {height})")
-        self.camera.set_perspective_projection(45, width / height, 0.01, 10_000)
+        self.camera.set_perspective_projection(70, width / height, 0.01, 10_000)
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
         if not self._right_clicked and event.buttons() & Qt.MouseButton.RightButton:


### PR DESCRIPTION
All viewports now share the same camera position.

Perhaps in the future we can add configurations per viewport to allow different views.
