### PR TITLE
Improve toolbar labels

### DIFF
--- a/src/builtin_plugins/plugin/amulet/editor/_label.py
+++ b/src/builtin_plugins/plugin/amulet/editor/_label.py
@@ -1,49 +1,25 @@
-from PySide6.QtCore import QPoint, QSize, Qt
-from PySide6.QtGui import (
-    QColor,
-    QHideEvent,
-    QShowEvent,
-)
-from PySide6.QtWidgets import QGraphicsDropShadowEffect, QLabel, QWidget
+from PySide6.QtCore import QPoint
+from PySide6.QtGui import QShowEvent
+from PySide6.QtWidgets import QWidget, QPushButton
 
 
-class QHoverLabel(QLabel):
+class QHoverLabel(QPushButton):
     def __init__(self, text: str, parent: QWidget):
         super().__init__(parent.window())
-
         self._parent = parent
-
-        self.shadow = QGraphicsDropShadowEffect(self)
-        self.shadow.setBlurRadius(7)
-        self.shadow.setXOffset(1)
-        self.shadow.setYOffset(1)
-        self.shadow.setColor(QColor(0, 0, 0))
-
-        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.setGraphicsEffect(self.shadow)
-        self.setObjectName("hover_label")
         self.setText(text)
 
     def setText(self, text: str) -> None:
         super().setText(text)
-        self.setFixedSize(self.minimumSizeHint() + QSize(30, 6))
+        self.setFixedSize(self.sizeHint())
 
     def showEvent(self, event: QShowEvent) -> None:
+        super().showEvent(event)
         window = self.parentWidget()
         if window is not None:
             parent = self._parent
-            pos_gbl = parent.mapToGlobal(QPoint(0, 0))
-            pos_rel = window.mapFromGlobal(pos_gbl)
-            pos_mov = QPoint(
+            pos_rel = parent.mapTo(window, QPoint())
+            self.move(
                 pos_rel.x() + parent.width() + 3,
                 pos_rel.y() + (parent.height() - self.height()) // 2,
             )
-            self.move(pos_mov)
-
-        return super().showEvent(event)
-
-    def hideEvent(self, event: QHideEvent) -> None:
-        parent = self.parent()
-        assert isinstance(parent, QWidget)
-        parent.update()  # Fix rendering artifacts
-        return super().hideEvent(event)

--- a/src/builtin_plugins/plugin/amulet/editor/_toolbar_button.py
+++ b/src/builtin_plugins/plugin/amulet/editor/_toolbar_button.py
@@ -44,16 +44,6 @@ class ToolbarButton(SVGButton):
         super().__init__(icon_path, parent)
         self._hlbl_tooltip: QHoverLabel | None = None
 
-    def enterEvent(self, event: QEnterEvent) -> None:
-        if self._hlbl_tooltip is not None and len(self._hlbl_tooltip.text()) > 0:
-            self._hlbl_tooltip.show()
-        super().enterEvent(event)
-
-    def leaveEvent(self, event: QEvent) -> None:
-        if self._hlbl_tooltip is not None:
-            self._hlbl_tooltip.hide()
-        super().leaveEvent(event)
-
     def toolTip(self) -> str:
         return "" if self._hlbl_tooltip is None else self._hlbl_tooltip.text()
 
@@ -63,3 +53,11 @@ class ToolbarButton(SVGButton):
             self._hlbl_tooltip.hide()
         else:
             self._hlbl_tooltip.setText(label)
+
+    def show_tooltip(self) -> None:
+        if self._hlbl_tooltip is not None and len(self._hlbl_tooltip.text()) > 0:
+            self._hlbl_tooltip.show()
+
+    def hide_tooltip(self) -> None:
+        if self._hlbl_tooltip is not None:
+            self._hlbl_tooltip.hide()

--- a/src/builtin_plugins/plugin/amulet/editor/window/_toolbar.py
+++ b/src/builtin_plugins/plugin/amulet/editor/window/_toolbar.py
@@ -2,7 +2,7 @@ from typing import Callable
 import traceback
 from weakref import finalize, WeakMethod
 
-from PySide6.QtCore import QSize, Qt, QObject, QEvent, QPoint
+from PySide6.QtCore import QSize, Qt, QObject, QEvent, QPoint, QRect
 from PySide6.QtGui import (
     QMouseEvent,
     QResizeEvent,
@@ -104,8 +104,8 @@ LayoutCls: dict[Qt.Orientation, type[QVBoxLayout | QHBoxLayout]] = {
 class DynamicButtonWidget(QScrollArea):
     """A rearrangeable list of buttons."""
 
-    # orderChanged = Signal(list)
     resized = Signal[()]()
+    _widgets_moved = Signal[()]()
 
     def __init__(
         self,
@@ -143,6 +143,10 @@ class DynamicButtonWidget(QScrollArea):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setWidgetResizable(True)
+
+        self._widgets_moved.connect(
+            self._on_widgets_moved, Qt.ConnectionType.QueuedConnection
+        )
 
     def child_widget(self) -> QWidget:
         return self._widget
@@ -193,6 +197,7 @@ class DynamicButtonWidget(QScrollArea):
             if self._dragged_widget is not child:
                 self._layout.removeWidget(self._dragged_widget)
                 self._layout.insertWidget(i, self._dragged_widget)
+                self._widgets_moved.emit()
                 self._dragged = True
 
     def add_item(self, item: QWidget) -> None:
@@ -226,6 +231,7 @@ class DynamicButtonWidget(QScrollArea):
         )
         bar.setValue(bar.value() - event.angleDelta().y() // 5)
 
+        self._widgets_moved.emit()
         if self._dragged_widget is not None:
             self._move_dragged_to_cursor()
             return
@@ -268,12 +274,47 @@ class DynamicButtonWidget(QScrollArea):
             self.verticalScrollBar().setValue(self.verticalScrollBar().value() - 60)
         else:
             self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - 60)
+        self._widgets_moved.emit()
 
     def scroll_down(self) -> None:
         if self._orientation == Qt.Orientation.Vertical:
             self.verticalScrollBar().setValue(self.verticalScrollBar().value() + 60)
         else:
             self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() + 60)
+        self._widgets_moved.emit()
+
+    def show_labels(self) -> None:
+        visible_rect = QRect(-self._widget.pos(), self.viewport().size())
+        for i in range(self._layout.count()):
+            item = self._layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if isinstance(widget, ToolbarButton) and visible_rect.contains(
+                widget.geometry()
+            ):
+                widget.show_tooltip()
+
+    def hide_labels(self) -> None:
+        for i in range(self._layout.count()):
+            item = self._layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if isinstance(widget, ToolbarButton):
+                widget.hide_tooltip()
+
+    def _on_widgets_moved(self) -> None:
+        visible_rect = QRect(-self._widget.pos(), self.viewport().size())
+        for i in range(self._layout.count()):
+            item = self._layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if isinstance(widget, ToolbarButton):
+                widget.hide_tooltip()
+                if visible_rect.contains(widget.geometry()):
+                    widget.show_tooltip()
 
 
 class ToolBar(QWidget):
@@ -370,3 +411,29 @@ class ToolBar(QWidget):
         button.setIconSize(QSize(IconSize, IconSize))
         self._static_button_layout.insertWidget(0, button)
         return button
+
+    def enterEvent(self, event: QEnterEvent) -> None:
+        super().enterEvent(event)
+
+        self._dynamic_button_widget.show_labels()
+
+        for i in range(self._static_button_layout.count()):
+            item = self._static_button_layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if isinstance(widget, ToolbarButton):
+                widget.show_tooltip()
+
+    def leaveEvent(self, event: QEvent) -> None:
+        super().leaveEvent(event)
+
+        self._dynamic_button_widget.hide_labels()
+
+        for i in range(self._static_button_layout.count()):
+            item = self._static_button_layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if isinstance(widget, ToolbarButton):
+                widget.hide_tooltip()


### PR DESCRIPTION
Add a background to the label to make them easier to read on any background.
It uses a QPushButton because I like the style and couldn't find a good alternative.

Make all labels visible while hovering on the toolbar.
This should make it easier to find the correct button.
Previously only the currently hovered button would show the label.
This also works when scrolling and/or dragging.

Fixes #153