### PR TITLE
Allow a tab or tool to reject being closed

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,6 @@ warn_return_any = True
 python_version = 3.14
 explicit_package_bases = True
 warn_unused_ignores=True
-enable_incomplete_feature = TypeForm
 
 mypy_path = $MYPY_CONFIG_FILE_DIR/src,$MYPY_CONFIG_FILE_DIR/tests
 files =

--- a/src/plugin/amulet/editor/_level_tab/_toolbar/_toolbar_button.py
+++ b/src/plugin/amulet/editor/_level_tab/_toolbar/_toolbar_button.py
@@ -1,9 +1,12 @@
+from collections.abc import Callable
+
 from PySide6.QtCore import QSize, Qt, QEvent, QCoreApplication
-from PySide6.QtGui import QPixmap, QIcon
+from PySide6.QtGui import QPixmap, QIcon, QMouseEvent
 from PySide6.QtWidgets import QVBoxLayout, QPushButton
 from PySide6.QtSvgWidgets import QSvgWidget
 
 from amulet.app.exception import CatchExceptionDialog
+from amulet.app.qt.signal import TypeFormSignal
 
 from ._hover_label import HoverLabel
 
@@ -30,6 +33,9 @@ class SVGButton(QPushButton):
 
 
 class ToolbarButton(SVGButton):
+    # The button has been clicked. If the callback is called, the click is vetoed.
+    pre_clicked = TypeFormSignal(Callable[[], None])
+
     def __init__(
         self,
         name: str | tuple[str, str, str | None],
@@ -62,3 +68,25 @@ class ToolbarButton(SVGButton):
     def hide_tooltip(self) -> None:
         if self._tooltip is not None:
             self._tooltip.hide()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() != Qt.MouseButton.LeftButton:
+            event.ignore()
+            return
+
+        if self.hitButton(event.position().toPoint()):
+            veto = False
+
+            def set_veto() -> None:
+                nonlocal veto
+                veto = True
+
+            self.pre_clicked.emit(set_veto)
+
+            if not veto:
+                self.setChecked(True)
+                self.clicked.emit()
+                event.accept()
+                return
+        self.setDown(False)
+        event.ignore()

--- a/src/plugin/amulet/editor/_level_tab/_widget.py
+++ b/src/plugin/amulet/editor/_level_tab/_widget.py
@@ -1,12 +1,16 @@
 from dataclasses import dataclass
+import weakref
+from collections.abc import Callable
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QStackedWidget
 
 from amulet.level import Level
 
-from .._tab import WindowTabClose
+from amulet.app.exception import CatchExceptionDialog
+
+from .._tab import TabAboutToHide, TabAboutToClose, ToolAboutToHide
 from ._toolbar import ToolBar, ToolbarButton
 from ..dock._impl import DockMainWidget
 
@@ -18,7 +22,7 @@ class LayoutStorage:
     widget: QWidget
 
 
-class LevelTabWidget(QWidget, WindowTabClose):
+class LevelTabWidget(QWidget, TabAboutToClose, TabAboutToHide):
     def __init__(self, level: Level) -> None:
         super().__init__()
         self._level = level
@@ -37,7 +41,17 @@ class LevelTabWidget(QWidget, WindowTabClose):
 
         self._initialised = False
 
-    def close_tab(self) -> bool:
+    def tab_about_to_hide(self) -> bool:
+        widget = self._widget_stack.currentWidget()
+        if isinstance(widget, ToolAboutToHide):
+            return widget.tool_about_to_hide()
+        return True
+
+    def tab_about_to_close(self) -> bool:
+        widget = self._widget_stack.currentWidget()
+        if isinstance(widget, ToolAboutToHide):
+            if not widget.tool_about_to_hide():
+                return False
         # TODO: If the level has unsaved changes, ask the user if they want to save them.
         return True
 
@@ -64,9 +78,32 @@ class LevelTabWidget(QWidget, WindowTabClose):
         self._widget_stack.addWidget(widget)
         button = ToolbarButton(name, icon_path)
 
-        def show_widget() -> None:
-            self._widget_stack.setCurrentWidget(widget)
+        weak_widget_stack = weakref.ref(self._widget_stack)
 
+        def pre_show_widget(veto: Callable[[], None]) -> None:
+            widget_stack = weak_widget_stack()
+            if widget_stack is None:
+                return
+            current_widget = widget_stack.currentWidget()
+            if widget is current_widget:
+                return
+            if isinstance(current_widget, ToolAboutToHide):
+                with CatchExceptionDialog(
+                    f"Error in {current_widget}.tool_about_to_hide()"
+                ):
+                    if not current_widget.tool_about_to_hide():
+                        veto()
+
+        def show_widget() -> None:
+            widget_stack = weak_widget_stack()
+            if widget_stack is None:
+                return
+            current_widget = widget_stack.currentWidget()
+            if widget is current_widget:
+                return
+            widget_stack.setCurrentWidget(widget)
+
+        button.pre_clicked.connect(pre_show_widget, type=Qt.ConnectionType.DirectConnection)
         button.clicked.connect(show_widget)
         self._toolbar.add_layout_button(button)
         self._tool_id_to_storage[identifier] = LayoutStorage(identifier, button, widget)
@@ -77,7 +114,7 @@ class LevelTabWidget(QWidget, WindowTabClose):
 
 class LevelTabWidgetAPI:
     def __init__(self, level_tab: LevelTabWidget) -> None:
-        self._level_tab = level_tab
+        self._level_tab = weakref.ref(level_tab)
 
     def add_tool(
         self,
@@ -96,8 +133,12 @@ class LevelTabWidgetAPI:
             1) The widget that is displayed when the tool is selected.
             2) The identifier for a dock layout.
         """
-        self._level_tab.add_tool(identifier, name, icon_path, widget)
+        level_tab = self._level_tab()
+        if level_tab is not None:
+            level_tab.add_tool(identifier, name, icon_path, widget)
 
     def activate_tool(self, identifier: str) -> None:
         """This simulates the user clicking the button for the tool."""
-        self._level_tab.activate_tool(identifier)
+        level_tab = self._level_tab()
+        if level_tab is not None:
+            level_tab.activate_tool(identifier)

--- a/src/plugin/amulet/editor/_level_tab/_widget.py
+++ b/src/plugin/amulet/editor/_level_tab/_widget.py
@@ -103,7 +103,9 @@ class LevelTabWidget(QWidget, TabAboutToClose, TabAboutToHide):
                 return
             widget_stack.setCurrentWidget(widget)
 
-        button.pre_clicked.connect(pre_show_widget, type=Qt.ConnectionType.DirectConnection)
+        button.pre_clicked.connect(
+            pre_show_widget, type=Qt.ConnectionType.DirectConnection
+        )
         button.clicked.connect(show_widget)
         self._toolbar.add_layout_button(button)
         self._tool_id_to_storage[identifier] = LayoutStorage(identifier, button, widget)

--- a/src/plugin/amulet/editor/_main_window.py
+++ b/src/plugin/amulet/editor/_main_window.py
@@ -1,8 +1,9 @@
 import traceback
 from dataclasses import dataclass
+from collections.abc import Callable
 
-from PySide6.QtCore import QObject, Signal, QEvent, QCoreApplication, QThread
-from PySide6.QtGui import QCloseEvent, QShortcut
+from PySide6.QtCore import QObject, Signal, QEvent, QCoreApplication, QThread, Qt
+from PySide6.QtGui import QCloseEvent, QShortcut, QMouseEvent
 from PySide6.QtWidgets import (
     QWidget,
     QMainWindow,
@@ -12,15 +13,16 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
 
-from amulet.app.exception import CatchExceptionDialog, display_exception
-
 from amulet.level.abc import Level
+
+from amulet.app.exception import CatchExceptionDialog, display_exception
+from amulet.app.qt.signal import TypeFormSignal
 
 from plugin.amulet.inspector.inspector import InspectorTool
 
 from ._home_tab import HomeTabWidget
 from ._level_tab import LevelTabWidget, LevelTabWidgetAPI
-from ._tab import WindowTabClose
+from ._tab import TabAboutToClose, TabAboutToHide
 
 
 @dataclass(frozen=True)
@@ -28,6 +30,26 @@ class LevelTabStorage:
     level: Level
     widget: QWidget
     api: LevelTabWidgetAPI
+
+
+class TabBar(QTabBar):
+    # The tab is about to change. If the callback is called, the tab change is vetoed.
+    tabAboutToChange = TypeFormSignal(Callable[[], None])
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            index = self.tabAt(event.position().toPoint())
+            if index >= 0 and index != self.currentIndex():
+                veto = False
+
+                def set_veto() -> None:
+                    nonlocal veto
+                    veto = True
+
+                self.tabAboutToChange.emit(set_veto)
+                if veto:
+                    return
+        super().mousePressEvent(event)
 
 
 class EditorMainWindow(QMainWindow):
@@ -45,7 +67,8 @@ class EditorMainWindow(QMainWindow):
         self._central_widget.setLayout(self._central_layout)
 
         self._tabs = QTabWidget()
-        self._tab_bar = self._tabs.tabBar()
+        self._tab_bar = TabBar()
+        self._tabs.setTabBar(self._tab_bar)
         self._tabs.setStyleSheet("QTabBar::tab { min-width: 100px; }")
         self._tabs.setTabsClosable(True)
         self._tabs.setTabBarAutoHide(True)
@@ -60,6 +83,7 @@ class EditorMainWindow(QMainWindow):
         self._widget_to_storage: dict[QWidget, LevelTabStorage] = {}
         self._level_to_storage: dict[Level, LevelTabStorage] = {}
 
+        self._tab_bar.tabAboutToChange.connect(self._tab_changing)
         self._tabs.tabCloseRequested.connect(self._tab_close_requested)
 
         self._inspector: InspectorTool | None = None
@@ -89,6 +113,13 @@ class EditorMainWindow(QMainWindow):
         else:
             self._inspector.reload()
         self._inspector.show()
+
+    def _tab_changing(self, veto: Callable[[], None]) -> None:
+        widget = self._tabs.currentWidget()
+        if isinstance(widget, TabAboutToHide):
+            with CatchExceptionDialog(f"Error in {widget}.tab_about_to_hide()"):
+                if not widget.tab_about_to_hide():
+                    veto()
 
     def _tab_close_requested(self, index: int) -> None:
         with CatchExceptionDialog("Error in EditorMainWindow._tab_close_requested"):
@@ -156,6 +187,11 @@ class EditorMainWindow(QMainWindow):
         storage = self._level_to_storage.get(level)
         if storage is None:
             raise RuntimeError("Level tab does not exist")
+        current_widget = self._tabs.currentWidget()
+        if isinstance(current_widget, TabAboutToHide):
+            with CatchExceptionDialog(f"Error in {current_widget}.tab_about_to_hide()"):
+                if not current_widget.tab_about_to_hide():
+                    return
         self._tabs.setCurrentWidget(storage.widget)
 
     def request_close_level_tab(self, level: Level) -> bool:
@@ -166,14 +202,16 @@ class EditorMainWindow(QMainWindow):
             # We are not aware of this level
             return True
         widget = storage.widget
-        if isinstance(widget, WindowTabClose):
-            with CatchExceptionDialog("Failed closing tab"):
-                if not widget.close_tab():
+        if isinstance(widget, TabAboutToClose):
+            with CatchExceptionDialog(f"Error in {widget}.tab_about_to_close()"):
+                if not widget.tab_about_to_close():
                     # The tab vetoed the close
                     return False
         self._tabs.removeTab(self._tabs.indexOf(widget))
         self._level_to_storage.pop(level, None)
         self._widget_to_storage.pop(widget, None)
+        widget.setParent(None)
+        widget.deleteLater()
         return True
 
 

--- a/src/plugin/amulet/editor/_tab.py
+++ b/src/plugin/amulet/editor/_tab.py
@@ -1,7 +1,26 @@
-class WindowTabClose:
-    def close_tab(self) -> bool:
+class ToolAboutToHide:
+    def tool_about_to_hide(self) -> bool:
         """
-        Called just before the tab is closed.
+        Called when the tool is about to be hidden.
+        Return False to prevent the tool being hidden.
+        This is called when switching world tabs, switching tools, or closing the level tab.
+        """
+        return True
+
+
+class TabAboutToHide:
+    def tab_about_to_hide(self) -> bool:
+        """
+        Called when the tab is about to be hidden.
+        Return False to prevent the tab from being hidden.
+        """
+        return True
+
+
+class TabAboutToClose:
+    def tab_about_to_close(self) -> bool:
+        """
+        Called when the tab is about to be closed.
         Return False to prevent the tab from being closed.
         """
         return True

--- a/src/plugin/amulet/editor/api.py
+++ b/src/plugin/amulet/editor/api.py
@@ -1,3 +1,4 @@
 """This is the public interface to interact with the editor."""
 
 from ._main_window import get_amulet_editor
+from ._tab import ToolAboutToHide


### PR DESCRIPTION
Some tools may need to confirm with the user that they can be closed (eg if there are unsaved changes)
This allows the tabs and tools to get notified just before switching/closing to notify the user and either accept or reject the change.