### PR TITLE
Fix invoke warning

### DIFF
--- a/src/amulet/app/invoke/_invoke.py
+++ b/src/amulet/app/invoke/_invoke.py
@@ -45,10 +45,11 @@ class Promise(QObject, Generic[T]):
             QueuedConnection will add the function to the thread's event queue and return immediately.
             BlockingQueuedConnection is a blocking form of QueuedConnection. It can only be used if :meth:`start` is called from a different thread to parent.
         """
-        super().__init__(parent)
+        super().__init__()
 
         # Move to the thread
         self.moveToThread(parent.thread())
+        self.setParent(parent)
 
         # Connect slot
         self._start.connect(self._execute, connection_type)


### PR DESCRIPTION
Invoke may be called from a different thread to parent. Parent cannot be set until the object is in parent's thread.